### PR TITLE
feat(Feature) 곡 상세 조회 기능 API 구현 #18

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/band/entity/BandSession.java
+++ b/src/main/java/com/deulbull/performance/domain/band/entity/BandSession.java
@@ -1,7 +1,7 @@
 package com.deulbull.performance.domain.band.entity;
 
 import com.deulbull.performance.domain.band.entity.enums.SessionType;
-import com.deulbull.performance.domain.performancesSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/deulbull/performance/domain/band/repository/BandSessionRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/band/repository/BandSessionRepository.java
@@ -1,0 +1,20 @@
+package com.deulbull.performance.domain.band.repository;
+
+import com.deulbull.performance.domain.band.entity.BandSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BandSessionRepository extends JpaRepository<BandSession, Long> {
+    @Query("""
+           select bs
+           from BandSession bs
+           left join fetch bs.person p
+           where bs.performanceSong.id = :performanceSongId
+           order by bs.sessionType asc, p.name asc
+           """)
+    List<BandSession> findAllByPerformanceSongIdWithPerson(Long performanceSongId);
+}

--- a/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
@@ -1,12 +1,11 @@
 package com.deulbull.performance.domain.performance.entity;
 
-import com.deulbull.performance.domain.performancesSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import com.deulbull.performance.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 @Entity
 @Getter

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/entity/PerformanceSong.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/entity/PerformanceSong.java
@@ -1,4 +1,4 @@
-package com.deulbull.performance.domain.performancesSongs.entity;
+package com.deulbull.performance.domain.performanceSongs.entity;
 
 import com.deulbull.performance.domain.performance.entity.Performance;
 import com.deulbull.performance.domain.song.entity.Song;

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/exception/PerformanceSongsErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/exception/PerformanceSongsErrorCode.java
@@ -1,0 +1,17 @@
+package com.deulbull.performance.domain.performanceSongs.exception;
+
+import com.deulbull.performance.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.deulbull.performance.global.constant.StaticValue.NOT_FOUND;
+
+@AllArgsConstructor
+@Getter
+public enum PerformanceSongsErrorCode implements BaseResponseCode {
+    PERFORMANCE_SONGS_404_NOT_FOUND("PERFORMANCE_SONGS_404_NOT_FOUND", NOT_FOUND, "해당 ID의 곡을 찾을 수 없습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/exception/PerformanceSongsNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/exception/PerformanceSongsNotFoundException.java
@@ -1,0 +1,10 @@
+package com.deulbull.performance.domain.performanceSongs.exception;
+
+import com.deulbull.performance.domain.performance.exception.PerformanceErrorCode;
+import com.deulbull.performance.global.exception.BaseException;
+
+public class PerformanceSongsNotFoundException extends BaseException {
+    public PerformanceSongsNotFoundException() {
+        super(PerformanceSongsErrorCode.PERFORMANCE_SONGS_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
@@ -1,0 +1,12 @@
+package com.deulbull.performance.domain.performanceSongs.repository;
+
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PerformanceSongsRepository extends JpaRepository<PerformanceSong, Long> {
+    Optional<PerformanceSong> findWithSongById(Long id);
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsService.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsService.java
@@ -1,0 +1,8 @@
+package com.deulbull.performance.domain.performanceSongs.service;
+
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+
+public interface PerformanceSongsService {
+    // 곡 정보 상세 조회
+    PerformanceSongsDetailResponseDto getPerformanceSongsDetail(Long performanceSongId);
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsServiceImpl.java
@@ -1,0 +1,60 @@
+package com.deulbull.performance.domain.performanceSongs.service;
+
+import com.deulbull.performance.domain.band.entity.BandSession;
+import com.deulbull.performance.domain.band.repository.BandSessionRepository;
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.performanceSongs.exception.PerformanceSongsNotFoundException;
+import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import com.deulbull.performance.domain.song.entity.Song;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceSongsServiceImpl implements PerformanceSongsService {
+    private final PerformanceSongsRepository performanceSongsRepository;
+    private final BandSessionRepository bandSessionRepository;
+
+    @Override
+    public PerformanceSongsDetailResponseDto getPerformanceSongsDetail(Long performanceSongId) {
+        PerformanceSong ps = performanceSongsRepository.findWithSongById(performanceSongId)
+                .orElseThrow(PerformanceSongsNotFoundException::new);
+
+        Song s = ps.getSong();
+        String releaseDateStr = (s.getReleaseDate() != null)
+                ? s.getReleaseDate().format(DateTimeFormatter.ISO_DATE)
+                : null;
+        // 트랙 생성 (곡 정보)
+        PerformanceSongsDetailResponseDto.Track track =
+                new PerformanceSongsDetailResponseDto.Track(
+                        ps.getLikes(),
+                        s.getTitle(),
+                        s.getArtist(),
+                        s.getAlbum(),
+                        s.getGenre(),
+                        releaseDateStr,
+                        s.getYoutubeUrl(),
+                        s.getLyrics(),
+                        s.getAlbumImgUrl()
+                );
+
+        // BandSession + Person 로드
+        List<BandSession> sessions =
+                bandSessionRepository.findAllByPerformanceSongIdWithPerson(performanceSongId);
+
+        // 팀 생성 (세션 정보 + 이름 + 인스타 아이디)
+        List<PerformanceSongsDetailResponseDto.Team> team = sessions.stream()
+                .map(bs -> new PerformanceSongsDetailResponseDto.Team(
+                        bs.getSessionType(),
+                        bs.getPerson() != null ? bs.getPerson().getName() : null,
+                        bs.getPerson() != null ? bs.getPerson().getInstagramId() : null
+                ))
+                .toList();
+
+        return new PerformanceSongsDetailResponseDto(track, team);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/web/controller/PerformanceSongsController.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/web/controller/PerformanceSongsController.java
@@ -1,0 +1,21 @@
+package com.deulbull.performance.domain.performanceSongs.web.controller;
+
+import com.deulbull.performance.domain.performanceSongs.service.PerformanceSongsService;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tracks")
+@RequiredArgsConstructor
+public class PerformanceSongsController {
+
+    private final PerformanceSongsService performanceSongsService;
+    @GetMapping("/{performanceSongId}")
+    public PerformanceSongsDetailResponseDto getPerformanceSongDetails(@PathVariable Long performanceSongId) {
+        return performanceSongsService.getPerformanceSongsDetail(performanceSongId);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/web/dto/PerformanceSongsDetailResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/web/dto/PerformanceSongsDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.deulbull.performance.domain.performanceSongs.web.dto;
+
+import com.deulbull.performance.domain.band.entity.enums.SessionType;
+
+import java.util.List;
+
+public record PerformanceSongsDetailResponseDto (
+        Track track,
+        List<Team> team
+) {
+    public record Track(
+            int likes,
+            String title,
+            String artist,
+            String album,
+            String genre,
+            String releaseDate,
+            String youtubeUrl,
+            String lyrics,
+            String albumImgUrl
+    ) {}
+
+    public record Team(
+            SessionType session,
+            String name,
+            String instagramId
+    ) {}
+}

--- a/src/test/java/com/deulbull/performance/domain/booking/web/controller/PerformanceSongsControllerTest.java
+++ b/src/test/java/com/deulbull/performance/domain/booking/web/controller/PerformanceSongsControllerTest.java
@@ -1,0 +1,91 @@
+package com.deulbull.performance.domain.booking.web.controller;
+
+import com.deulbull.performance.domain.band.entity.enums.SessionType;
+import com.deulbull.performance.domain.performanceSongs.exception.PerformanceSongsNotFoundException;
+import com.deulbull.performance.domain.performanceSongs.service.PerformanceSongsService;
+import com.deulbull.performance.domain.performanceSongs.web.controller.PerformanceSongsController;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import com.deulbull.performance.global.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class PerformanceSongsControllerTest {
+
+    private MockMvc mockMvc;
+    private PerformanceSongsService performanceSongsService;
+
+    @BeforeEach
+    void setUp() {
+        performanceSongsService = Mockito.mock(PerformanceSongsService.class);
+        var controller = new PerformanceSongsController(performanceSongsService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET /api/tracks/{id} → 상세 성공(JSON Content-Type 포함)")
+    void getTrackDetail_success() throws Exception {
+        Long performanceSongId = 101L;
+
+        var track = new PerformanceSongsDetailResponseDto.Track(
+                37, "너에게 난, 나에게 넌", "자전거 탄 풍경",
+                "Classic", "Ballad", "2001-06-14",
+                "https://youtu.be/abcd", "가사 전문 ...",
+                "https://img.example/album.jpg"
+        );
+
+        var team = List.of(
+                new PerformanceSongsDetailResponseDto.Team(SessionType.VOCAL, "강범준", "beom_jun"),
+                new PerformanceSongsDetailResponseDto.Team(SessionType.DRUM,  "김주호", "juho_kim")
+        );
+
+        var dto = new PerformanceSongsDetailResponseDto(track, team);
+
+        Mockito.when(performanceSongsService.getPerformanceSongsDetail(eq(performanceSongId)))
+                .thenReturn(dto);
+
+        mockMvc.perform(get("/api/tracks/{performanceSongId}", performanceSongId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.track.likes").value(37))
+                .andExpect(jsonPath("$.team", hasSize(2)));
+    }
+    @Test
+    @DisplayName("GET /api/tracks/{id} → 존재하지 않으면 404 + JSON 에러바디")
+    void getTrackDetail_notFound() throws Exception {
+        Long performanceSongId = 9999L;
+
+        // ✅ 커스텀 예외를 던지도록 스텁 (메서드명 정확!)
+        Mockito.when(performanceSongsService.getPerformanceSongsDetail(eq(performanceSongId)))
+                .thenThrow(new PerformanceSongsNotFoundException());
+
+        mockMvc.perform(get("/api/tracks/{performanceSongId}", performanceSongId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value("PERFORMANCE_SONGS_404_NOT_FOUND"))
+                .andExpect(jsonPath("$.httpStatus").value(404))
+                .andExpect(jsonPath("$.message").value("해당 ID의 곡을 찾을 수 없습니다."));
+    }
+}
+


### PR DESCRIPTION
## 연관 이슈
- close #18 

## 작업 내용
- 곡 리스트에서 곡 상세 정보로 넘어갈때 전달하는 API 구현
- PerformanceSongsDetailResponseDto 생성
- Repository 생성 (BandSessionRepo, PerformaceSongsRepo)
- 곡 상세 정보 조회 Service 생성
- /api/tracks/{performanceId}에 맞춘 Controller 생성
- 404 에러처리 핸들러 생성

## 논의하고 싶은 내용
- 이거 근데 N+1 문제가 발생할 여지가 있는데 그건 추후에 고민해 보겠음

## 공유하고 싶은 내용
- 스프링 부트 내 Test기능 사용
- 곡 상세 정보 조회
- <img width="1398" height="408" alt="image" src="https://github.com/user-attachments/assets/1a06144d-52e6-4820-bdb9-f9baa545da87" />
- 404 ERROR
- <img width="1399" height="448" alt="image" src="https://github.com/user-attachments/assets/e90f879f-01e0-49e7-b4a8-18c86d3a0ce4" />
