### PR TITLE
fix(Controller): PerformanceSongsControllerController 리턴 방식 수정

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/web/controller/PerformanceSongsController.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/web/controller/PerformanceSongsController.java
@@ -2,6 +2,7 @@ package com.deulbull.performance.domain.performanceSongs.web.controller;
 
 import com.deulbull.performance.domain.performanceSongs.service.PerformanceSongsService;
 import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import com.deulbull.performance.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,13 +10,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/tracks")
+@RequestMapping("/tracks")
 @RequiredArgsConstructor
 public class PerformanceSongsController {
 
     private final PerformanceSongsService performanceSongsService;
     @GetMapping("/{performanceSongId}")
-    public PerformanceSongsDetailResponseDto getPerformanceSongDetails(@PathVariable Long performanceSongId) {
-        return performanceSongsService.getPerformanceSongsDetail(performanceSongId);
+    public SuccessResponse<PerformanceSongsDetailResponseDto> getPerformanceSongDetails(@PathVariable Long performanceSongId) {
+        return SuccessResponse.ok(performanceSongsService.getPerformanceSongsDetail(performanceSongId));
     }
 }


### PR DESCRIPTION
## 연관 이슈
- close #21 

## 작업 내용
- 기존: PerformanceSongsDetailsResponseDto -> 변경: SuccessResponse
- RequestMapping에서 /api구문 삭제

## 논의하고 싶은 내용

## 공유하고 싶은 내용
- 작동 결과 (Postman 사용)
- 
<img width="941" height="595" alt="image" src="https://github.com/user-attachments/assets/fc1b7144-89bd-4361-a1d4-23a9cb84c671" />

## 기타
