### PR TITLE
Feat(like): 곡 좋아요 추가/취소 기능 구현

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/LikesOnly.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/LikesOnly.java
@@ -1,0 +1,5 @@
+package com.deulbull.performance.domain.performanceSongs.repository;
+
+public interface LikesOnly {
+    int getLikes();
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
@@ -2,6 +2,9 @@ package com.deulbull.performance.domain.performanceSongs.repository;
 
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,4 +12,9 @@ import java.util.Optional;
 @Repository
 public interface PerformanceSongsRepository extends JpaRepository<PerformanceSong, Long> {
     Optional<PerformanceSong> findWithSongById(Long id);
+    @Modifying
+    @Query(value = "update performance_song set likes = greatest(likes+:delta, 0) where id = :id", nativeQuery = true)
+    int likes(@Param("id") Long id, @Param("delta") int delta);
+
+    Optional<LikesOnly> findLikesById(Long performanceSongId);
 }

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsService.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsService.java
@@ -1,8 +1,12 @@
 package com.deulbull.performance.domain.performanceSongs.service;
 
 import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsLikeRequestDto;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsLikeResponseDto;
 
 public interface PerformanceSongsService {
     // 곡 정보 상세 조회
     PerformanceSongsDetailResponseDto getPerformanceSongsDetail(Long performanceSongId);
+    // 곡 좋아요 추가/취소
+    PerformanceSongsLikeResponseDto getPerformanceSongsLike(Long performanceSongId, PerformanceSongsLikeRequestDto liked);
 }

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/service/PerformanceSongsServiceImpl.java
@@ -4,11 +4,15 @@ import com.deulbull.performance.domain.band.entity.BandSession;
 import com.deulbull.performance.domain.band.repository.BandSessionRepository;
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import com.deulbull.performance.domain.performanceSongs.exception.PerformanceSongsNotFoundException;
+import com.deulbull.performance.domain.performanceSongs.repository.LikesOnly;
 import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
 import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsLikeRequestDto;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsLikeResponseDto;
 import com.deulbull.performance.domain.song.entity.Song;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -56,5 +60,22 @@ public class PerformanceSongsServiceImpl implements PerformanceSongsService {
                 .toList();
 
         return new PerformanceSongsDetailResponseDto(track, team);
+    }
+
+    @Transactional
+    @Override
+    public PerformanceSongsLikeResponseDto getPerformanceSongsLike(Long performanceSongId, PerformanceSongsLikeRequestDto liked) {
+        int delta = liked.liked() ? 1 : -1; // true: +1 / false -1
+        int updated = performanceSongsRepository.likes(performanceSongId, delta);
+        if (updated == 0) {
+            if (!performanceSongsRepository.existsById(performanceSongId)) {
+                throw new PerformanceSongsNotFoundException();
+            }
+            // 존재하지만 값 변화 없음 -> 계속 진행
+        }
+        int currentLikes = performanceSongsRepository.findLikesById(performanceSongId)
+                .map(LikesOnly::getLikes)
+                .orElseThrow(PerformanceSongsNotFoundException::new);
+        return new PerformanceSongsLikeResponseDto(currentLikes, liked.liked());
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/web/controller/PerformanceSongsController.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/web/controller/PerformanceSongsController.java
@@ -2,12 +2,12 @@ package com.deulbull.performance.domain.performanceSongs.web.controller;
 
 import com.deulbull.performance.domain.performanceSongs.service.PerformanceSongsService;
 import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsDetailResponseDto;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsLikeRequestDto;
+import com.deulbull.performance.domain.performanceSongs.web.dto.PerformanceSongsLikeResponseDto;
 import com.deulbull.performance.global.response.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/tracks")
@@ -15,8 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class PerformanceSongsController {
 
     private final PerformanceSongsService performanceSongsService;
+
     @GetMapping("/{performanceSongId}")
     public SuccessResponse<PerformanceSongsDetailResponseDto> getPerformanceSongDetails(@PathVariable Long performanceSongId) {
         return SuccessResponse.ok(performanceSongsService.getPerformanceSongsDetail(performanceSongId));
+    }
+
+    @PostMapping("/{performanceSongId}/like")
+    public SuccessResponse<PerformanceSongsLikeResponseDto> getlike(@PathVariable Long performanceSongId, @Valid @RequestBody PerformanceSongsLikeRequestDto liked) {
+        return SuccessResponse.ok(performanceSongsService.getPerformanceSongsLike(performanceSongId, liked));
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/web/dto/PerformanceSongsLikeRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/web/dto/PerformanceSongsLikeRequestDto.java
@@ -1,0 +1,8 @@
+package com.deulbull.performance.domain.performanceSongs.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PerformanceSongsLikeRequestDto (
+        @NotNull(message = "잘못된 인자입니다.")
+        Boolean liked
+){}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/web/dto/PerformanceSongsLikeResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/web/dto/PerformanceSongsLikeResponseDto.java
@@ -1,0 +1,6 @@
+package com.deulbull.performance.domain.performanceSongs.web.dto;
+
+public record PerformanceSongsLikeResponseDto (
+    int likes,
+    boolean liked
+) {}


### PR DESCRIPTION
## 연관 이슈
- close #23 

## 작업 내용
- Controller에 유효성 검사를 통해 Param을 확인하고 처리함
- request dto와 response dto를 생성해 일관성 유지
- Repository에 like update와 like 조회를 위해 프로젝션 생성
- Service에서 liked의 값을 확인해 좋아요 증감을 처리

## 논의하고 싶은 내용

## 공유하고 싶은 내용
- 테이블에서 값 하나만 처리하려면 어케 할까 고민했는데 JPA에서 projection을 만들어서 하라는거 보고 공유합니다.
- https://learngoeson.tistory.com/51

## 기타
- 400
- 
<img width="1047" height="753" alt="image" src="https://github.com/user-attachments/assets/75b9bbb9-e7fa-4bef-95ad-60881d87cf1c" />
- 200
- 
<img width="1020" height="813" alt="image" src="https://github.com/user-attachments/assets/99c33034-2d47-419a-8468-cbf826ff5c0b" />
