### PR TITLE
feat(jwt) 관리자 회원가입 API 구현

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
@@ -2,8 +2,14 @@ package com.deulbull.performance.domain.admin.service;
 
 import com.deulbull.performance.domain.admin.web.dto.AdminLoginRequestDto;
 import com.deulbull.performance.domain.admin.web.dto.AdminLoginResponseDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminSignupRequestDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminSignupResponseDto;
+import jakarta.validation.Valid;
 
 public interface AdminService {
     // 로그인
     public AdminLoginResponseDto login(AdminLoginRequestDto adminLoginRequestDto);
+
+    // 회원가입
+    AdminSignupResponseDto signup(@Valid AdminSignupRequestDto adminSignupRequestDto);
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
@@ -1,15 +1,24 @@
 package com.deulbull.performance.domain.admin.service;
 
 import com.deulbull.performance.domain.admin.entity.Admin;
+import com.deulbull.performance.domain.admin.entity.enums.AdminRole;
 import com.deulbull.performance.domain.admin.exception.AdminInvalidPasswordException;
 import com.deulbull.performance.domain.admin.repository.AdminRepository;
 import com.deulbull.performance.domain.admin.web.dto.AdminLoginRequestDto;
 import com.deulbull.performance.domain.admin.web.dto.AdminLoginResponseDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminSignupRequestDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminSignupResponseDto;
+import com.deulbull.performance.domain.band.entity.Band;
+import com.deulbull.performance.domain.band.exception.BandNotFoundException;
+import com.deulbull.performance.domain.band.repository.BandRepository;
 import com.deulbull.performance.domain.performance.entity.Performance;
+import com.deulbull.performance.domain.performance.exception.PerformanceNotFoundException;
+import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
 import com.deulbull.performance.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -18,6 +27,8 @@ public class AdminServiceImpl implements AdminService {
     private final JwtTokenProvider jwtTokenProvider;
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
+    private final PerformanceRepository performanceRepository;
+    private final BandRepository bandRepository;
 
     // 로그인
     @Override
@@ -38,11 +49,49 @@ public class AdminServiceImpl implements AdminService {
         Performance performance = admin.getPerformance();
         String token = jwtTokenProvider.createToken(admin);
 
+        // 3. 반환
         return new AdminLoginResponseDto(
                 token,
                 performance.getDescription(),
                 admin.getBand().getBandName(),
                 admin.getRole().toString()
         );
+    }
+
+    @Transactional
+    @Override
+    public AdminSignupResponseDto signup(AdminSignupRequestDto adminSignupRequestDto) {
+        String password = adminSignupRequestDto.getPassword();
+        AdminRole role = adminSignupRequestDto.getRole();
+        Long performanceId = adminSignupRequestDto.getPerformanceId();
+        Long bandId = adminSignupRequestDto.getBandId();
+
+        // 1. Performance 조회
+        Performance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(PerformanceNotFoundException::new);
+
+        // 2. Band 조회
+        Band band = bandRepository.findById(bandId)
+                .orElseThrow(BandNotFoundException::new);
+
+        // 3. 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(password);
+
+        // 4. Admin 생성
+        Admin admin = Admin.builder()
+                .role(role)
+                .password(encodedPassword)
+                .performance(performance)
+                .band(band)
+                .build();
+
+        // 5. DB에 저장
+        Admin savedAdmin = adminRepository.save(admin);
+
+        // 6. JWT 토큰 생성
+        String token = jwtTokenProvider.createToken(savedAdmin);
+
+        // 7. 반환
+        return new AdminSignupResponseDto(token);
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
@@ -3,6 +3,8 @@ package com.deulbull.performance.domain.admin.web.controller;
 import com.deulbull.performance.domain.admin.service.AdminService;
 import com.deulbull.performance.domain.admin.web.dto.AdminLoginRequestDto;
 import com.deulbull.performance.domain.admin.web.dto.AdminLoginResponseDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminSignupRequestDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminSignupResponseDto;
 import com.deulbull.performance.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +19,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class AdminController {
     private final AdminService adminService;
 
+    // 로그인
     @PostMapping("/auth/login")
     public SuccessResponse<AdminLoginResponseDto> login(@RequestBody @Valid AdminLoginRequestDto adminLoginRequestDto) {
         AdminLoginResponseDto data = adminService.login(adminLoginRequestDto);
+        return SuccessResponse.created(data);
+    }
+
+    // 회원가입
+    @PostMapping("/auth/signup")
+    public SuccessResponse<AdminSignupResponseDto> signup(
+            @RequestBody @Valid AdminSignupRequestDto adminSignupRequestDto) {
+        AdminSignupResponseDto data = adminService.signup(adminSignupRequestDto);
         return SuccessResponse.created(data);
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
@@ -23,7 +23,7 @@ public class AdminController {
     @PostMapping("/auth/login")
     public SuccessResponse<AdminLoginResponseDto> login(@RequestBody @Valid AdminLoginRequestDto adminLoginRequestDto) {
         AdminLoginResponseDto data = adminService.login(adminLoginRequestDto);
-        return SuccessResponse.created(data);
+        return SuccessResponse.ok(data);
     }
 
     // 회원가입

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
@@ -8,12 +8,12 @@ import com.deulbull.performance.domain.admin.web.dto.AdminSignupResponseDto;
 import com.deulbull.performance.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {

--- a/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminSignupRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminSignupRequestDto.java
@@ -1,0 +1,28 @@
+package com.deulbull.performance.domain.admin.web.dto;
+
+import com.deulbull.performance.domain.admin.entity.enums.AdminRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminSignupRequestDto {
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+
+    @NotNull(message = "역할은 필수입니다")
+    private AdminRole role;
+
+    @NotNull(message = "공연 ID는 필수입니다")
+    private Long performanceId;
+
+    @NotNull(message = "밴드 ID는 필수입니다")
+    private Long bandId;
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminSignupResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminSignupResponseDto.java
@@ -1,0 +1,4 @@
+package com.deulbull.performance.domain.admin.web.dto;
+
+public record AdminSignupResponseDto() {
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminSignupResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminSignupResponseDto.java
@@ -1,4 +1,6 @@
 package com.deulbull.performance.domain.admin.web.dto;
 
-public record AdminSignupResponseDto() {
+public record AdminSignupResponseDto(
+        String token
+) {
 }

--- a/src/main/java/com/deulbull/performance/domain/band/exception/BandErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/band/exception/BandErrorCode.java
@@ -1,0 +1,17 @@
+package com.deulbull.performance.domain.band.exception;
+
+import com.deulbull.performance.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.deulbull.performance.global.constant.StaticValue.BAD_REQUEST;
+
+@AllArgsConstructor
+@Getter
+public enum BandErrorCode implements BaseResponseCode {
+    BAND_404_NOT_FOUND("BAND_404_NOT_FOUND", BAD_REQUEST, "해당 ID의 밴드를 찾을 수 없습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/deulbull/performance/domain/band/exception/BandNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/band/exception/BandNotFoundException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.band.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class BandNotFoundException extends BaseException {
+    public BandNotFoundException() {
+        super(BandErrorCode.BAND_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/band/repository/BandRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/band/repository/BandRepository.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.band.repository;
+
+import com.deulbull.performance.domain.band.entity.Band;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BandRepository extends JpaRepository<Band, Long> {
+}

--- a/src/main/java/com/deulbull/performance/global/config/SecurityConfig.java
+++ b/src/main/java/com/deulbull/performance/global/config/SecurityConfig.java
@@ -37,13 +37,13 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/admin/auth/login").permitAll()
-                        .requestMatchers("/api/admin/**").authenticated() // 관리자만 관리자 페이지 접근 가능
-                        .requestMatchers("/api/**").permitAll()  // 다른 API는 모두 접근
+                        .requestMatchers("/api/admin/auth/login", "/api/admin/auth/signup").permitAll()
+                        .requestMatchers("/api/admin/**").authenticated()
+                        .requestMatchers("/api/**").permitAll()
                         .anyRequest().permitAll()
                 )
 
-                // 4. JWT 필터 등록
+                // JWT 필터 등록
                 // 스프링 시큐리티에서 제공하는 로그인 처리 필터인 UsernamePasswordAuthenticationFilter 전에 실행되도록 설정
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
 


### PR DESCRIPTION
## 연관 이슈
- close #26 

## 작업 내용
- 관리자 회원가입 로직을 구현했습니다.

> 201(생성 성공)
<img width="476" height="189" alt="image" src="https://github.com/user-attachments/assets/9ced6072-16a6-475a-a11c-17c9df8609b4" />

> 404(해당 Id의 밴드 찾을 수 없음)
<img width="537" height="261" alt="image" src="https://github.com/user-attachments/assets/680075b2-3bb6-4f9f-b4c3-4436f4732a93" />

> 404(해당 Id의 공연 찾을 수 없음)
<img width="535" height="302" alt="image" src="https://github.com/user-attachments/assets/df2c3086-71e3-4772-b360-4db8818926be" />


## 공유하고 싶은 내용
- JWT token 관련 사용방법은 다음 PR 코멘트를 참고해주세요. #24 

