### PR TITLE
feat(current): (관리자) 현재곡 조회

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/repository/AdminPerformanceRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/repository/AdminPerformanceRepository.java
@@ -1,0 +1,25 @@
+package com.deulbull.performance.domain.admin.repository;
+
+import com.deulbull.performance.domain.admin.entity.Admin;
+import com.deulbull.performance.domain.song.projection.CurrentSongProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminPerformanceRepository extends JpaRepository<Admin, Long> {
+    @Query("""
+                select
+                    s.title as title,
+                    s.artist      as artist,
+                    s.albumImgUrl as albumImgUrl
+                from Admin a
+                    join a.performance p
+                    join p.currentSong ps
+                    join ps.song s
+                where a.id = :adminId
+            """)
+    Optional<CurrentSongProjection> findCurrentSongDtoByAdminId(Long adminId);
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceService.java
@@ -1,0 +1,7 @@
+package com.deulbull.performance.domain.admin.service;
+
+import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
+
+public interface AdminPerformanceService {
+    AdminCurrentSongResponseDto getCurrentSong(Long adminId);
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
@@ -1,0 +1,26 @@
+package com.deulbull.performance.domain.admin.service;
+
+import com.deulbull.performance.domain.admin.entity.Admin;
+import com.deulbull.performance.domain.admin.exception.AdminNotFoundException;
+import com.deulbull.performance.domain.admin.repository.AdminPerformanceRepository;
+import com.deulbull.performance.domain.admin.repository.AdminRepository;
+import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
+import com.deulbull.performance.domain.song.projection.CurrentSongProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPerformanceServiceImpl implements AdminPerformanceService {
+
+    private final AdminRepository adminRepository;
+    private final AdminPerformanceRepository adminPerformanceRepository;
+
+    @Override
+    public AdminCurrentSongResponseDto getCurrentSong(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+        CurrentSongProjection currentSong = adminPerformanceRepository.findCurrentSongDtoByAdminId(admin.getId()).orElseThrow(AdminNotFoundException::new);
+        return new AdminCurrentSongResponseDto(currentSong.getTitle(), currentSong.getArtist(), currentSong.getAlbumImgUrl());
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminPerformanceController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminPerformanceController.java
@@ -1,0 +1,26 @@
+package com.deulbull.performance.domain.admin.web.controller;
+
+import com.deulbull.performance.domain.admin.service.AdminPerformanceService;
+import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
+import com.deulbull.performance.global.response.SuccessResponse;
+import com.deulbull.performance.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminPerformanceController {
+
+    private final AdminPerformanceService adminPerformanceService;
+
+    @GetMapping("/performance/current")
+    public SuccessResponse<AdminCurrentSongResponseDto> getCurrentSong(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long adminId = userDetails.getAdminId();
+        return SuccessResponse.ok(adminPerformanceService.getCurrentSong(adminId));
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminCurrentSongResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminCurrentSongResponseDto.java
@@ -1,0 +1,8 @@
+package com.deulbull.performance.domain.admin.web.dto;
+
+public record AdminCurrentSongResponseDto(
+        String title,
+        String artist,
+        String albumImgUrl
+) {
+}

--- a/src/main/java/com/deulbull/performance/domain/song/projection/CurrentSongProjection.java
+++ b/src/main/java/com/deulbull/performance/domain/song/projection/CurrentSongProjection.java
@@ -1,0 +1,7 @@
+package com.deulbull.performance.domain.song.projection;
+
+public interface CurrentSongProjection {
+    String getTitle();
+    String getArtist();
+    String getAlbumImgUrl();
+}


### PR DESCRIPTION
## 연관 이슈
- close #29 

## 작업 내용
- 현재 진행 중인 곡을 조회하는 api
- api요청 시 title, artist, albumImgUrl을 보내준다

## 논의하고 싶은 내용
- api 기능 별로 service, controller 분리하는 게 코드 가독성 부분에서 이점이 있어보입니다.

## 공유하고 싶은 내용

## 기타
- 200 OK
<img width="1064" height="776" alt="image" src="https://github.com/user-attachments/assets/203aeabb-ad74-4b33-bd03-e7c8fd14a3b9" />
