### PR TITLE
feat(setlist): 공연 셋리스트 정보 조회

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
@@ -1,8 +1,12 @@
 package com.deulbull.performance.domain.performance.service;
 
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
 
 public interface PerformanceService {
     // 공연 정보 상세 조회
     PerformanceDetailResponseDto getPerformanceDetail(Long performanceId);
+
+    // 공연 셋리스트 조회
+    PerformanceSetlistResponse getPerformanceSetlist(Long performanceId);
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -113,7 +113,7 @@ public class PerformanceServiceImpl implements PerformanceService {
         // currentSong이 null일 수 있는 경우 처리
         int currentSongId = performance.getCurrentSong() != null
                 ? performance.getCurrentSong().getOrderInPerformance()
-                : 0;
+                : -1;
 
         return new PerformanceSetlistResponse(currentSongId, setList);
     }

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -7,11 +7,17 @@ import com.deulbull.performance.domain.performance.repository.PerformanceImageRe
 import com.deulbull.performance.domain.performance.repository.PerformanceMoreLinkRepository;
 import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto.MoreLinkDto;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse.PerformanceSetListDetail;
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
 import com.deulbull.performance.domain.song.exception.SongNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -20,6 +26,7 @@ public class PerformanceServiceImpl implements PerformanceService {
     private final PerformanceRepository performanceRepository;
     private final PerformanceImageRepository performanceImageRepository;
     private final PerformanceMoreLinkRepository performanceMoreLinkRepository;
+    private final PerformanceSongsRepository performanceSongsRepository;
 
     @Override
     public PerformanceDetailResponseDto getPerformanceDetail(Long performanceId) {
@@ -42,6 +49,7 @@ public class PerformanceServiceImpl implements PerformanceService {
         String currentSongArtist = null;
         String currentSongAlbumUrl = null;
 
+
         if (performance.getCurrentSong() != null) {
             // 404: 해당 ID의 곡 없음
             if (performance.getCurrentSong().getSong() == null) {
@@ -53,9 +61,9 @@ public class PerformanceServiceImpl implements PerformanceService {
         }
 
         // morelink 리스트 생성
-        List<PerformanceDetailResponseDto.MoreLinkDto> moreLinks = performanceMoreLinkRepository.findAllByPerformanceId(performance.getId())
+        List<MoreLinkDto> moreLinks = performanceMoreLinkRepository.findAllByPerformanceId(performance.getId())
                 .stream()
-                .map(p -> new PerformanceDetailResponseDto.MoreLinkDto(
+                .map(p -> new MoreLinkDto(
                         p.getType().toString(),
                         p.getName(),
                         p.getUrl()
@@ -81,5 +89,32 @@ public class PerformanceServiceImpl implements PerformanceService {
                 performance.getLocation(),
                 moreLinks
         );
+    }
+
+    // 공연 셋리스트 조회
+    @Override
+    public PerformanceSetlistResponse getPerformanceSetlist(Long performanceId) {
+        Performance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(PerformanceNotFoundException::new); // 404: 존재하지 않는 공연
+
+        List<PerformanceSong> performanceSongs = performanceSongsRepository.findByPerformanceId(performance.getId());
+
+        // performanceSongs를 PerformanceSetListDetail 리스트로 변환 및 정렬
+        List<PerformanceSetListDetail> setList = performanceSongs.stream()
+                .map(p -> new PerformanceSetListDetail(
+                        p.getOrderInPerformance(),
+                        p.getId(),
+                        p.getSong().getTitle(),
+                        p.getSong().getArtist()
+                ))
+                .sorted(Comparator.comparingInt(PerformanceSetListDetail::order)) // order 기준 정렬
+                .toList();
+
+        // currentSong이 null일 수 있는 경우 처리
+        int currentSongId = performance.getCurrentSong() != null
+                ? performance.getCurrentSong().getOrderInPerformance()
+                : 0;
+
+        return new PerformanceSetlistResponse(currentSongId, setList);
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
@@ -2,9 +2,12 @@ package com.deulbull.performance.domain.performance.web.controller;
 
 import com.deulbull.performance.domain.performance.service.PerformanceService;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
 import com.deulbull.performance.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/performances")
@@ -13,12 +16,21 @@ public class PerformanceController {
 
     private final PerformanceService performanceService;
 
-    // 공연 상세 조회 API
+    // 공연 상세 조회
     @GetMapping("/{performanceId}")
     public SuccessResponse<PerformanceDetailResponseDto> getPerformanceDetail(
             @PathVariable Long performanceId
     ) {
-        PerformanceDetailResponseDto responseDto = performanceService.getPerformanceDetail(performanceId);
-        return SuccessResponse.ok(responseDto);
+        PerformanceDetailResponseDto response = performanceService.getPerformanceDetail(performanceId);
+        return SuccessResponse.ok(response);
+    }
+
+    // 공연 셋리스트 조회
+    @GetMapping("/{performanceId}/setlist")
+    public SuccessResponse<PerformanceSetlistResponse> getPerformanceSetList(
+            @PathVariable Long performanceId
+    ){
+        PerformanceSetlistResponse response = performanceService.getPerformanceSetlist(performanceId);
+        return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
@@ -3,11 +3,11 @@ import java.util.List;
 
 public record PerformanceSetlistResponse(
         int nowPlayingOrder,
-        List<PerformanceSetListDetail> performanceSetListDetails
+        List<PerformanceSetListDetail> setlist
 ) {
     public record PerformanceSetListDetail(
         int order,
-        int performanceSongId,
+        Long performanceSongId,
         String title,
         String artist
     ){

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
@@ -1,0 +1,15 @@
+package com.deulbull.performance.domain.performance.web.dto;
+import java.util.List;
+
+public record PerformanceSetlistResponse(
+        int nowPlayingOrder,
+        List<PerformanceSetListDetail> performanceSetListDetails
+) {
+    public record PerformanceSetListDetail(
+        int order,
+        int performanceSongId,
+        String title,
+        String artist
+    ){
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
@@ -2,6 +2,9 @@ package com.deulbull.performance.domain.performanceSongs.repository;
 
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +13,11 @@ import java.util.Optional;
 @Repository
 public interface PerformanceSongsRepository extends JpaRepository<PerformanceSong, Long> {
     Optional<PerformanceSong> findWithSongById(Long id);
+    @Modifying
+    @Query(value = "update performance_song set likes = greatest(likes+:delta, 0) where id = :id", nativeQuery = true)
+    int likes(@Param("id") Long id, @Param("delta") int delta);
+
+    Optional<LikesOnly> findLikesById(Long performanceSongId);
 
     List<PerformanceSong> findByPerformanceId(Long id);
 }

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
@@ -2,19 +2,14 @@ package com.deulbull.performance.domain.performanceSongs.repository;
 
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PerformanceSongsRepository extends JpaRepository<PerformanceSong, Long> {
     Optional<PerformanceSong> findWithSongById(Long id);
-    @Modifying
-    @Query(value = "update performance_song set likes = greatest(likes+:delta, 0) where id = :id", nativeQuery = true)
-    int likes(@Param("id") Long id, @Param("delta") int delta);
 
-    Optional<LikesOnly> findLikesById(Long performanceSongId);
+    List<PerformanceSong> findByPerformanceId(Long id);
 }


### PR DESCRIPTION
## 연관 이슈
- close #36

## 작업 내용
- 셋리스트 조회 API 구현
> 200(조회 성공) - 공연 시작 전
<img width="490" height="540" alt="image" src="https://github.com/user-attachments/assets/f020363f-9bf4-4e3b-aefa-5b685f462ee7" />

> 200(조회 성공) - 공연 시작 후
- 곡 생성, 공연 생성 등 api 구현 후 추가해두겠습니다.

> 404(해당 ID의 공연 없음)
<img width="511" height="243" alt="image" src="https://github.com/user-attachments/assets/bb43d5a6-7d8b-4a96-a564-167ad2f3fc4b" />

## 공유 사항
- 현재 진행중인 곡이 없는 경우 -1 로 표기했습니다.