### PR TITLE
feat(next/previous) (관리자) 다음 곡 넘기기 + 조회 / 이전 곡 되돌리기 + 조회

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceErrorCode.java
@@ -1,0 +1,18 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.response.code.BaseResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static com.deulbull.performance.global.constant.StaticValue.NOT_FOUND;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminPerformanceErrorCode implements BaseResponseCode {
+    ADMIN_SONG_404_NOT_FOUND("ADMIN_SONG_404_NOT_FOUND", NOT_FOUND, "해당 공연에 등록된 곡이 없습니다."),
+    ADMIN_PERFORMANCE_404_NOT_FOUND("ADMIN_PERFORMANCE_404_NOT_FOUND", NOT_FOUND, "해당 공연의 ID가 없습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class AdminPerformanceNotFoundException extends BaseException {
+    public AdminPerformanceNotFoundException() {
+        super(AdminPerformanceErrorCode.ADMIN_PERFORMANCE_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminSongNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminSongNotFoundException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class AdminSongNotFoundException extends BaseException {
+    public AdminSongNotFoundException() {
+        super(AdminPerformanceErrorCode.ADMIN_SONG_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceService.java
@@ -3,5 +3,12 @@ package com.deulbull.performance.domain.admin.service;
 import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
 
 public interface AdminPerformanceService {
+    // 현재 곡 조회
     AdminCurrentSongResponseDto getCurrentSong(Long adminId);
+
+    // 다음 곡 전달
+    AdminCurrentSongResponseDto getNextSong(Long adminId);
+
+    // 이전 곡 전달
+    AdminCurrentSongResponseDto getPreviousSong(Long adminId);
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
@@ -2,9 +2,15 @@ package com.deulbull.performance.domain.admin.service;
 
 import com.deulbull.performance.domain.admin.entity.Admin;
 import com.deulbull.performance.domain.admin.exception.AdminNotFoundException;
+import com.deulbull.performance.domain.admin.exception.AdminPerformanceNotFoundException;
+import com.deulbull.performance.domain.admin.exception.AdminSongNotFoundException;
 import com.deulbull.performance.domain.admin.repository.AdminPerformanceRepository;
 import com.deulbull.performance.domain.admin.repository.AdminRepository;
 import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
+import com.deulbull.performance.domain.performance.entity.Performance;
+import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
 import com.deulbull.performance.domain.song.projection.CurrentSongProjection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +21,8 @@ public class AdminPerformanceServiceImpl implements AdminPerformanceService {
 
     private final AdminRepository adminRepository;
     private final AdminPerformanceRepository adminPerformanceRepository;
+    private final PerformanceSongsRepository performanceSongsRepository;
+    private final PerformanceRepository performanceRepository;
 
     @Override
     public AdminCurrentSongResponseDto getCurrentSong(Long adminId) {
@@ -23,4 +31,94 @@ public class AdminPerformanceServiceImpl implements AdminPerformanceService {
         CurrentSongProjection currentSong = adminPerformanceRepository.findCurrentSongDtoByAdminId(admin.getId()).orElseThrow(AdminNotFoundException::new);
         return new AdminCurrentSongResponseDto(currentSong.getTitle(), currentSong.getArtist(), currentSong.getAlbumImgUrl());
     }
+
+    @Override
+    public AdminCurrentSongResponseDto getNextSong(Long adminId) {
+        // Admin / Performance
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+        Performance performance = admin.getPerformance();
+        if (performance == null) throw new AdminPerformanceNotFoundException();
+
+        // 현재 곡 / 공연 ID
+        PerformanceSong current = performance.getCurrentSong();
+        Long performanceId = performance.getId();
+
+        // 다음 곡(없으면 첫 곡으로 순환)
+        PerformanceSong nextEntity;
+        if (current != null) {
+            Integer currOrder = current.getOrderInPerformance();
+            nextEntity = performanceSongsRepository
+                    .findFirstByPerformance_IdAndOrderInPerformanceGreaterThanOrderByOrderInPerformanceAsc(
+                            performanceId, currOrder
+                    )
+                    .orElseGet(() -> performanceSongsRepository
+                            .findFirstByPerformance_IdOrderByOrderInPerformanceAsc(performanceId)
+                            .orElseThrow(AdminSongNotFoundException::new)
+                    );
+        } else {
+            nextEntity = performanceSongsRepository
+                    .findFirstByPerformance_IdOrderByOrderInPerformanceAsc(performanceId)
+                    .orElseThrow(AdminSongNotFoundException::new);
+        }
+
+        // current_song 갱신
+        performance.setCurrentSong(nextEntity);
+        performanceRepository.save(performance);
+
+        // 프로젝션으로 응답 만들기
+        CurrentSongProjection nextView = performanceSongsRepository
+                .findProjectionById(nextEntity.getId())
+                .orElseThrow(AdminSongNotFoundException::new);
+
+        return new AdminCurrentSongResponseDto(
+                nextView.getTitle(),
+                nextView.getArtist(),
+                nextView.getAlbumImgUrl()
+        );
+    }
+
+    @Override
+    public AdminCurrentSongResponseDto getPreviousSong(Long adminId) {
+        // Admin & Performance
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+        Performance performance = admin.getPerformance();
+        if (performance == null) throw new AdminPerformanceNotFoundException();
+
+        PerformanceSong current = performance.getCurrentSong();
+        Long performanceId = performance.getId();
+
+        // 이전 곡 선택 (없으면 마지막 곡으로 순환)
+        PerformanceSong prevEntity;
+        if (current != null) {
+            Integer currOrder = current.getOrderInPerformance();
+            prevEntity = performanceSongsRepository
+                    .findFirstByPerformance_IdAndOrderInPerformanceLessThanOrderByOrderInPerformanceDesc(
+                            performanceId, currOrder
+                    )
+                    .orElseGet(() ->
+                            performanceSongsRepository
+                                    .findFirstByPerformance_IdOrderByOrderInPerformanceDesc(performanceId)
+                                    .orElseThrow(AdminSongNotFoundException::new)
+                    );
+        } else {
+            // 현재곡이 비어있다면 마지막 곡을 현재곡으로 시작
+            prevEntity = performanceSongsRepository
+                    .findFirstByPerformance_IdOrderByOrderInPerformanceDesc(performanceId)
+                    .orElseThrow(AdminSongNotFoundException::new);
+        }
+
+        // current_song 갱신
+        performance.setCurrentSong(prevEntity);
+        performanceRepository.save(performance);
+
+        // 프로젝션으로 응답 생성
+        CurrentSongProjection view = performanceSongsRepository
+                .findProjectionById(prevEntity.getId())
+                .orElseThrow(AdminSongNotFoundException::new);
+
+        return new AdminCurrentSongResponseDto(view.getTitle(), view.getArtist(), view.getAlbumImgUrl());
+    }
+
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminPerformanceController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminPerformanceController.java
@@ -18,9 +18,19 @@ public class AdminPerformanceController {
 
     private final AdminPerformanceService adminPerformanceService;
 
-    @GetMapping("/performance/current")
+    @GetMapping("/performances/current")
     public SuccessResponse<AdminCurrentSongResponseDto> getCurrentSong(@AuthenticationPrincipal CustomUserDetails userDetails) {
         Long adminId = userDetails.getAdminId();
         return SuccessResponse.ok(adminPerformanceService.getCurrentSong(adminId));
+    }
+    @PostMapping("/performances/next")
+    public SuccessResponse<AdminCurrentSongResponseDto> getNextSong(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long adminId = userDetails.getAdminId();
+        return SuccessResponse.ok(adminPerformanceService.getNextSong(adminId));
+    }
+    @PostMapping("/performances/previous")
+    public SuccessResponse<AdminCurrentSongResponseDto> getPreviousSong(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long adminId = userDetails.getAdminId();
+        return SuccessResponse.ok(adminPerformanceService.getPreviousSong(adminId));
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
@@ -1,6 +1,7 @@
 package com.deulbull.performance.domain.performanceSongs.repository;
 
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.song.projection.CurrentSongProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,31 @@ public interface PerformanceSongsRepository extends JpaRepository<PerformanceSon
     int likes(@Param("id") Long id, @Param("delta") int delta);
 
     Optional<LikesOnly> findLikesById(Long performanceSongId);
+
+    // 다음 곡: current.orderInPerformance보다 큰 곡 중 가장 작은 순서
+    Optional<PerformanceSong> findFirstByPerformance_IdAndOrderInPerformanceGreaterThanOrderByOrderInPerformanceAsc(
+            Long performanceId, Integer orderInPerformance
+    );
+
+    // 첫 곡: 현재곡이 없거나 마지막에서 다음이 없을 때
+    Optional<PerformanceSong> findFirstByPerformance_IdOrderByOrderInPerformanceAsc(Long performanceId);
+
+    // 이전 곡: 현재 순번보다 작은 것 중 가장 큰 순번
+    Optional<PerformanceSong>
+    findFirstByPerformance_IdAndOrderInPerformanceLessThanOrderByOrderInPerformanceDesc(
+            Long performanceId, Integer orderInPerformance
+    );
+
+    // 마지막 곡
+    Optional<PerformanceSong>
+    findFirstByPerformance_IdOrderByOrderInPerformanceDesc(Long performanceId);
+
+    // ps.id로 프로젝션 1건 찾기
+    @Query("""
+        select s.title as title, s.artist as artist, s.albumImgUrl as albumImgUrl
+        from PerformanceSong ps
+        join ps.song s
+        where ps.id = :performanceSongId
+    """)
+    Optional<CurrentSongProjection> findProjectionById(@Param("performanceSongId") Long performanceSongId);
 }


### PR DESCRIPTION
## 연관 이슈
- close #33 

## 작업 내용
- Performance.current_song_id를 변경하고 변경된 id로 song을 조회해 data 리턴

## 논의하고 싶은 내용

## 공유하고 싶은 내용
- next 200
- 
<img width="1073" height="804" alt="image" src="https://github.com/user-attachments/assets/8ee64d11-2699-4aa8-8561-4264f3a3fcc3" />
- previous 200
- 
<img width="1072" height="847" alt="image" src="https://github.com/user-attachments/assets/8485b974-c7eb-4d4e-a6f2-c5ccfb8c6a21" />