### PR TITLE
feat(admin): 단체 문자 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// CoolSMS
+	implementation 'net.nurigo:sdk:4.2.7'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
@@ -1,0 +1,14 @@
+package com.deulbull.performance.domain.admin.service;
+
+import com.deulbull.performance.domain.admin.web.dto.AdminMessageRequestDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminMessageTargetCountResponseDto;
+import jakarta.validation.Valid;
+
+public interface AdminMessageService {
+
+    // 문자 발송 대상 인원 수 조회
+    AdminMessageTargetCountResponseDto getMessageTargetCount(Long adminId);
+
+    // 단체 문자 발송
+    void sendBulkMessage(Long adminId, @Valid AdminMessageRequestDto adminMessageRequestDto);
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.service.DefaultMessageService;
-import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -23,8 +22,6 @@ import java.util.List;
 public class AdminMessageServiceImpl implements AdminMessageService {
     private final AdminRepository adminRepository;
     private final BookingRepository bookingRepository;
-    private final Logger logger;
-
 
     @Value("${sms.api.key}")
     private String apiKey;
@@ -90,14 +87,17 @@ public class AdminMessageServiceImpl implements AdminMessageService {
                 smsService.sendOne(new SingleMessageSendingRequest(message));
                 successCount++;
             } catch (Exception e) {
-                logger.error("문자 발송 실패 ({}): {}", booking.getPerformance(), e.getMessage());
+
+                System.out.println("문자 발송 실패 (" + booking.getPerformance() + "): " + e.getMessage());
                 failCount++;
             }
         }
 
-        // 로그 남기기
-        logger.info("[문자 발송 결과] adminId={}, performanceId={}, success={}, fail={}",
-                adminId, performance.getId(), successCount, failCount);
+        // 테스트
+        System.out.println("[문자 발송 결과] adminId=" + adminId
+                + ", performanceId=" + performance.getId()
+                + ", success=" + successCount
+                + ", fail=" + failCount);
     }
 
 

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -1,0 +1,57 @@
+package com.deulbull.performance.domain.admin.service;
+
+import com.deulbull.performance.domain.admin.entity.Admin;
+import com.deulbull.performance.domain.admin.exception.AdminNotFoundException;
+import com.deulbull.performance.domain.admin.repository.AdminRepository;
+import com.deulbull.performance.domain.admin.web.dto.AdminMessageRequestDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminMessageTargetCountResponseDto;
+import com.deulbull.performance.domain.booking.entity.Booking;
+import com.deulbull.performance.domain.booking.repository.BookingRepository;
+import com.deulbull.performance.domain.performance.entity.Performance;
+import com.deulbull.performance.global.response.SuccessResponse;
+import com.deulbull.performance.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMessageServiceImpl implements AdminMessageService {
+    private final AdminRepository adminRepository;
+    private final BookingRepository bookingRepository;
+
+    // 문자 발송 대상 인원 수 조회
+    @Override
+    public AdminMessageTargetCountResponseDto getMessageTargetCount(Long adminId) {
+        // 404: 해당 ID의 관리자 없음
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+        Performance performance = admin.getPerformance();
+
+        List<Booking> bookings = bookingRepository.findAllByPerformanceId(performance.getId());
+
+        // 예매자 수
+        int smsTargetCount = bookings.size();
+
+        // 총 예매 인원 수
+        int totalBookingCount = bookings.stream()
+                .mapToInt(Booking::getHeadCount)
+                .sum();
+
+        // 반환
+        return new AdminMessageTargetCountResponseDto(
+                smsTargetCount,
+                totalBookingCount
+        );
+    }
+
+
+
+
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -8,16 +8,14 @@ import com.deulbull.performance.domain.admin.web.dto.AdminMessageTargetCountResp
 import com.deulbull.performance.domain.booking.entity.Booking;
 import com.deulbull.performance.domain.booking.repository.BookingRepository;
 import com.deulbull.performance.domain.performance.entity.Performance;
-import com.deulbull.performance.global.response.SuccessResponse;
-import com.deulbull.performance.global.security.CustomUserDetails;
-import jakarta.validation.Valid;
+import net.nurigo.sdk.message.model.Message;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.InsufficientAuthenticationException;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-
 import java.util.List;
 
 @Service
@@ -25,6 +23,15 @@ import java.util.List;
 public class AdminMessageServiceImpl implements AdminMessageService {
     private final AdminRepository adminRepository;
     private final BookingRepository bookingRepository;
+    private final Logger logger;
+
+
+    @Value("${sms.api.key}")
+    private String apiKey;
+    @Value("${sms.api.secret}")
+    private String apiSecret;
+    @Value("${sms.from}")
+    private String sender;
 
     // 문자 발송 대상 인원 수 조회
     @Override
@@ -51,7 +58,47 @@ public class AdminMessageServiceImpl implements AdminMessageService {
         );
     }
 
+    // 단체 문자 발송
+    @Override
+    public void sendBulkMessage(Long adminId, AdminMessageRequestDto adminMessageRequestDto) {
+        // 404: 관리자 없음
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+        Performance performance = admin.getPerformance();
 
+        // 공연별 예매자 조회
+        List<Booking> bookings = bookingRepository.findAllByPerformanceId(performance.getId());
+
+        DefaultMessageService smsService =
+                NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+
+        int successCount = 0;
+        int failCount = 0;
+
+        // 문자 발송
+        for (Booking booking : bookings) {
+            try {
+                Message message = new Message();
+                message.setFrom(sender);
+                message.setTo(booking.getPhoneNumber());
+                message.setText(adminMessageRequestDto.getMessage());
+
+                if ("LMS".equalsIgnoreCase(adminMessageRequestDto.getType())) {
+                    message.setSubject(adminMessageRequestDto.getTitle());
+                }
+
+                smsService.sendOne(new SingleMessageSendingRequest(message));
+                successCount++;
+            } catch (Exception e) {
+                logger.error("문자 발송 실패 ({}): {}", booking.getPerformance(), e.getMessage());
+                failCount++;
+            }
+        }
+
+        // 로그 남기기
+        logger.info("[문자 발송 결과] adminId={}, performanceId={}, success={}, fail={}",
+                adminId, performance.getId(), successCount, failCount);
+    }
 
 
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
@@ -12,7 +12,4 @@ public interface AdminService {
 
     // 예매 현황 전체 조회
     BookingListResponseDto getBookingList(Long adminId, int page, int size);
-
-    // 문자 발송 대상 인원 수 조회
-    AdminMessageTargetCountResponseDto getMessageTargetCount(Long adminId);
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
@@ -1,7 +1,6 @@
 package com.deulbull.performance.domain.admin.service;
 
 import com.deulbull.performance.domain.admin.web.dto.*;
-import com.deulbull.performance.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 
 public interface AdminService {

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
@@ -153,29 +153,4 @@ public class AdminServiceImpl implements AdminService {
                 bookingDtos
         );
     }
-
-    // 문자 발송 대상 인원 수 조회
-    @Override
-    public AdminMessageTargetCountResponseDto getMessageTargetCount(Long adminId) {
-        // 404: 해당 ID의 관리자 없음
-        Admin admin = adminRepository.findById(adminId)
-                .orElseThrow(AdminNotFoundException::new);
-        Performance performance = admin.getPerformance();
-
-        List<Booking> bookings = bookingRepository.findAllByPerformanceId(performance.getId());
-
-        // 예매자 수
-        int smsTargetCount = bookings.size();
-
-        // 총 예매 인원 수
-        int totalBookingCount = bookings.stream()
-                .mapToInt(Booking::getHeadCount)
-                .sum();
-
-        // 반환
-        return new AdminMessageTargetCountResponseDto(
-                smsTargetCount,
-                totalBookingCount
-        );
-    }
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.deulbull.performance.domain.admin.web.controller;
 
+import com.deulbull.performance.domain.admin.service.AdminMessageService;
 import com.deulbull.performance.domain.admin.service.AdminService;
 import com.deulbull.performance.domain.admin.web.dto.*;
 import com.deulbull.performance.domain.booking.service.BookingService;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
     private final AdminService adminService;
     private final BookingService bookingService;
+    private final AdminMessageService adminMessageService;
 
     // 로그인
     @PostMapping("/auth/login")
@@ -91,7 +93,7 @@ public class AdminController {
             throw new InsufficientAuthenticationException("Authentication required");
         }
         Long adminId = userDetails.getAdminId();
-        AdminMessageTargetCountResponseDto response = adminService.getMessageTargetCount(adminId);
+        AdminMessageTargetCountResponseDto response = adminMessageService.getMessageTargetCount(adminId);
         return SuccessResponse.ok(response);
     }
 

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminMessageController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminMessageController.java
@@ -45,7 +45,7 @@ public class AdminMessageController {
         }
 
         Long adminId = userDetails.getAdminId();
-        AdminMessageTargetCountResponseDto data = adminMessageService.getMessageTargetCount(adminId, performanceId);
+        AdminMessageTargetCountResponseDto data = adminMessageService.getMessageTargetCount(adminId);
         return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminMessageController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminMessageController.java
@@ -1,0 +1,51 @@
+package com.deulbull.performance.domain.admin.web.controller;
+
+import com.deulbull.performance.domain.admin.service.AdminMessageService;
+import com.deulbull.performance.domain.admin.web.dto.AdminMessageRequestDto;
+import com.deulbull.performance.domain.admin.web.dto.AdminMessageTargetCountResponseDto;
+import com.deulbull.performance.global.response.SuccessResponse;
+import com.deulbull.performance.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+// 관리자 문자 발송 관련 API 컨트롤러
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/messages")
+public class AdminMessageController {
+
+    private final AdminMessageService adminMessageService;
+
+    // 특정 공연의 예매자들에게 단체 문자 발송
+    @PostMapping
+    public SuccessResponse<Void> sendBulkMessage(
+            @AuthenticationPrincipal(errorOnInvalidType = false) CustomUserDetails userDetails,
+            @RequestBody @Valid AdminMessageRequestDto adminMessageRequestDto
+    ) {
+        if (userDetails == null) {
+            throw new InsufficientAuthenticationException("Authentication required");
+        }
+
+        Long adminId = userDetails.getAdminId();
+        adminMessageService.sendBulkMessage(adminId, adminMessageRequestDto);
+        return SuccessResponse.ok(null);
+    }
+
+    // 단체 문자 발송 대상 인원 수 조회
+    @GetMapping("/performances/{performanceId}/count")
+    public SuccessResponse<AdminMessageTargetCountResponseDto> getMessageTargetCount(
+            @AuthenticationPrincipal(errorOnInvalidType = false) CustomUserDetails userDetails,
+            @PathVariable Long performanceId
+    ) {
+        if (userDetails == null) {
+            throw new InsufficientAuthenticationException("Authentication required");
+        }
+
+        Long adminId = userDetails.getAdminId();
+        AdminMessageTargetCountResponseDto data = adminMessageService.getMessageTargetCount(adminId, performanceId);
+        return SuccessResponse.ok(data);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminMessageRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/dto/AdminMessageRequestDto.java
@@ -1,0 +1,13 @@
+package com.deulbull.performance.domain.admin.web.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class AdminMessageRequestDto {
+    private String title;
+    private String message;
+    private String type;
+}


### PR DESCRIPTION
## 연관 이슈
- close #43 

## 작업 내용
- 로그인한 관리자 계정에 해당하는 공연의 모든 예매자에게 문자를 전송합니다.
- 문자 전송 기능은 coolSMS를 사용했습니다.
- coolsms 대시보드
<img width="781" height="273" alt="image" src="https://github.com/user-attachments/assets/da84251a-c137-4d36-ad39-3b7482ac91d7" />

- 문자 전송 화면
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/18eb18f3-7602-4d78-8a45-14d52b896786" />

> 200(발송 성공)
<img width="416" height="233" alt="image" src="https://github.com/user-attachments/assets/f859f5b0-387e-47d9-a0d2-c138e8b9c525" />


## 논의할 사항
- 발신 번호는 우선 제 개인 번호를 등록해두었으며 추후 들불 회장 번호로 변경할 예정입니다.