### PR TITLE
feat(admin): 관리자 예매 현황 조회에 이름 검색 기능 추가

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminService.java
@@ -11,5 +11,5 @@ public interface AdminService {
     AdminSignupResponseDto signup(@Valid AdminSignupRequestDto adminSignupRequestDto);
 
     // 예매 현황 전체 조회
-    BookingListResponseDto getBookingList(Long adminId, int page, int size);
+    BookingListResponseDto getBookingList(Long adminId, int page, int size, String search);
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
@@ -109,7 +109,7 @@ public class AdminServiceImpl implements AdminService {
     // 예매 현황 전체 조회
     @Override
     @Transactional(readOnly = true)
-    public BookingListResponseDto getBookingList(Long adminId, int page, int size) {
+    public BookingListResponseDto getBookingList(Long adminId, int page, int size, String search) {
         // 1. Admin 조회 (Performance 정보 포함 - EAGER로 자동 로드됨)
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(AdminNotFoundException::new);
@@ -119,14 +119,27 @@ public class AdminServiceImpl implements AdminService {
         // 2. 페이징 설정 (createdAt 기준 내림차순)
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        // 3. 예매 목록 조회
-        Page<Booking> bookingPage = bookingRepository.findByPerformance(performance, pageable);
+        // 3. 예매 목록 조회 (검색어가 있으면 이름 검색, 없으면 전체 조회)
+        Page<Booking> bookingPage;
+        Integer totalHeadCount;
+        long totalBookingCount;
 
-        // 4. 총 인원 수 및 총 예매 건수 조회
-        Integer totalHeadCount = bookingRepository.sumHeadCountByPerformance(performance);
-        long totalBookingCount = bookingRepository.countByPerformance(performance);
+        boolean hasSearchQuery = search != null && !search.trim().isEmpty();
 
-        // 5. DTO 변환
+        if (hasSearchQuery) {
+            // 검색어가 있는 경우
+            String trimmedSearch = search.trim();
+            bookingPage = bookingRepository.findByPerformanceAndNameContaining(performance, trimmedSearch, pageable);
+            totalHeadCount = bookingRepository.sumHeadCountByPerformanceAndNameContaining(performance, trimmedSearch);
+            totalBookingCount = bookingRepository.countByPerformanceAndNameContaining(performance, trimmedSearch);
+        } else {
+            // 검색어가 없는 경우 (전체 조회)
+            bookingPage = bookingRepository.findByPerformance(performance, pageable);
+            totalHeadCount = bookingRepository.sumHeadCountByPerformance(performance);
+            totalBookingCount = bookingRepository.countByPerformance(performance);
+        }
+
+        // 4. DTO 변환
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd HH:mm");
         List<BookingDto> bookingDtos = bookingPage.getContent().stream()
                 .map(booking -> new BookingDto(

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
@@ -41,7 +41,8 @@ public class AdminController {
     public SuccessResponse<BookingListResponseDto> getBookingList(
             @AuthenticationPrincipal(errorOnInvalidType = false) CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String search
     ) {
         // userDetails가 null이면 Spring Security의 AuthenticationEntryPoint가 처리
         if (userDetails == null) {
@@ -49,7 +50,7 @@ public class AdminController {
         }
 
         Long adminId = userDetails.getAdminId();
-        BookingListResponseDto data = adminService.getBookingList(adminId, page, size);
+        BookingListResponseDto data = adminService.getBookingList(adminId, page, size, search);
         return SuccessResponse.ok(data);
     }
 

--- a/src/main/java/com/deulbull/performance/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/repository/BookingRepository.java
@@ -17,12 +17,22 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     // 특정 공연의 예매 목록 조회 (페이징, createdAt 기준 정렬은 Pageable로 처리)
     Page<Booking> findByPerformance(Performance performance, Pageable pageable);
 
+    // 특정 공연의 예매 목록 조회 - 이름 검색 (페이징)
+    Page<Booking> findByPerformanceAndNameContaining(Performance performance, String name, Pageable pageable);
+
     // 특정 공연의 총 예매 건수
     long countByPerformance(Performance performance);
+
+    // 특정 공연의 총 예매 건수 - 이름 검색
+    long countByPerformanceAndNameContaining(Performance performance, String name);
 
     // 특정 공연의 총 인원 수 합계
     @Query("SELECT COALESCE(SUM(b.headCount), 0) FROM Booking b WHERE b.performance = :performance")
     Integer sumHeadCountByPerformance(@Param("performance") Performance performance);
+
+    // 특정 공연의 총 인원 수 합계 - 이름 검색
+    @Query("SELECT COALESCE(SUM(b.headCount), 0) FROM Booking b WHERE b.performance = :performance AND b.name LIKE CONCAT('%', :name, '%')")
+    Integer sumHeadCountByPerformanceAndNameContaining(@Param("performance") Performance performance, @Param("name") String name);
 
     List<Booking> findAllByPerformanceId(Long performanceId);
 }


### PR DESCRIPTION
## 연관 이슈
- close #45 

## 작업 내용
- search 파라미터 추가
- 예매자 이름으로 검색 가능합니다.
- 부분검색이 가능합니다. ex) '김' 라고 검색하면 이름에 '김'가 포함된 사람 모두 리턴

## 논의하고 싶은 내용

## 공유하고 싶은 내용
