### PR TITLE
feat(cors): CORS 설정에 프론트엔드 URL(배포, 로컬) 추가

### DIFF
--- a/src/main/java/com/deulbull/performance/global/config/WebConfig.java
+++ b/src/main/java/com/deulbull/performance/global/config/WebConfig.java
@@ -9,7 +9,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000") // 실제 프론트 주소 명시
+                .allowedOrigins(
+                        // 사용자 페이지
+                        "http://localhost:3000",
+                        "https://deulbul.netlify.app",
+                        // 관리자 페이지
+                        "http://localhost:3002",
+                        "https://deulbul-admin.netlify.app"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowCredentials(true);
     }


### PR DESCRIPTION
## 연관 이슈
- close #47

## 작업 내용
- CORS 설정에 프론트엔드 Origin 추가
  - 사용자 페이지: `http://localhost:3000`, `https://deulbul.netlify.app`
  - 관리자 페이지: `http://localhost:3002`, `https://deulbul-admin.netlify.app`

## 논의하고 싶은 내용

## 공유하고 싶은 내용

## 기타
- 프론트엔드팀 배포 완료에 따른 설정 업데이트