### PR TITLE
feat: 밴드, 부원, 공연 생성 API 구현

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/band/repository/PersonRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/band/repository/PersonRepository.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.band.repository;
+
+import com.deulbull.performance.domain.band.entity.Person;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PersonRepository extends JpaRepository<Person, Long> {
+}

--- a/src/main/java/com/deulbull/performance/domain/band/service/BandService.java
+++ b/src/main/java/com/deulbull/performance/domain/band/service/BandService.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.band.service;
+
+import com.deulbull.performance.domain.band.web.dto.BandRequestDto;
+import com.deulbull.performance.domain.band.web.dto.BandResponseDto;
+
+public interface BandService {
+    // 밴드 생성
+    BandResponseDto createBand(BandRequestDto requestDto);
+}

--- a/src/main/java/com/deulbull/performance/domain/band/service/BandServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/band/service/BandServiceImpl.java
@@ -19,7 +19,7 @@ public class BandServiceImpl implements BandService {
         // 밴드 생성
         Band band = Band.builder()
                 .bandName(requestDto.bandName())
-                .logoUrl(requestDto.logoUrl())
+                .logoUrl(null) // TODO: 로고 필요시 S3 업로드 로직 추가
                 .build();
 
         bandRepository.save(band);

--- a/src/main/java/com/deulbull/performance/domain/band/service/BandServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/band/service/BandServiceImpl.java
@@ -1,0 +1,30 @@
+package com.deulbull.performance.domain.band.service;
+
+import com.deulbull.performance.domain.band.entity.Band;
+import com.deulbull.performance.domain.band.repository.BandRepository;
+import com.deulbull.performance.domain.band.web.dto.BandRequestDto;
+import com.deulbull.performance.domain.band.web.dto.BandResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BandServiceImpl implements BandService {
+    private final BandRepository bandRepository;
+
+    @Override
+    @Transactional
+    public BandResponseDto createBand(BandRequestDto requestDto) {
+        // 밴드 생성
+        Band band = Band.builder()
+                .bandName(requestDto.bandName())
+                .logoUrl(requestDto.logoUrl())
+                .build();
+
+        bandRepository.save(band);
+
+        // 응답 반환
+        return BandResponseDto.from(band);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/band/service/PersonService.java
+++ b/src/main/java/com/deulbull/performance/domain/band/service/PersonService.java
@@ -1,0 +1,11 @@
+package com.deulbull.performance.domain.band.service;
+
+import com.deulbull.performance.domain.band.web.dto.PersonRequestDto;
+import com.deulbull.performance.domain.band.web.dto.PersonResponseDto;
+
+import java.util.List;
+
+public interface PersonService {
+    // 여러 명의 Person 생성
+    List<PersonResponseDto> createPersons(List<PersonRequestDto> requestDtos);
+}

--- a/src/main/java/com/deulbull/performance/domain/band/service/PersonServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/band/service/PersonServiceImpl.java
@@ -1,0 +1,38 @@
+package com.deulbull.performance.domain.band.service;
+
+import com.deulbull.performance.domain.band.entity.Person;
+import com.deulbull.performance.domain.band.repository.PersonRepository;
+import com.deulbull.performance.domain.band.web.dto.PersonRequestDto;
+import com.deulbull.performance.domain.band.web.dto.PersonResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PersonServiceImpl implements PersonService {
+    private final PersonRepository personRepository;
+
+    @Override
+    @Transactional
+    public List<PersonResponseDto> createPersons(List<PersonRequestDto> requestDtos) {
+        // 여러 명의 Person 생성
+        List<Person> persons = requestDtos.stream()
+                .map(dto -> Person.builder()
+                        .studentId(dto.studentId())
+                        .name(dto.name())
+                        .instagramId(dto.instagramId())
+                        .build())
+                .toList();
+
+        // 일괄 저장
+        List<Person> savedPersons = personRepository.saveAll(persons);
+
+        // 응답 반환
+        return savedPersons.stream()
+                .map(PersonResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/band/web/controller/BandController.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/controller/BandController.java
@@ -1,0 +1,26 @@
+package com.deulbull.performance.domain.band.web.controller;
+
+import com.deulbull.performance.domain.band.service.BandService;
+import com.deulbull.performance.domain.band.web.dto.BandRequestDto;
+import com.deulbull.performance.domain.band.web.dto.BandResponseDto;
+import com.deulbull.performance.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/bands")
+@RequiredArgsConstructor
+public class BandController {
+
+    private final BandService bandService;
+
+    // 밴드 생성 API
+    @PostMapping
+    public SuccessResponse<BandResponseDto> createBand(
+            @Valid @RequestBody BandRequestDto requestDto
+    ) {
+        BandResponseDto response = bandService.createBand(requestDto);
+        return SuccessResponse.created(response);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/band/web/controller/PersonController.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/controller/PersonController.java
@@ -1,0 +1,28 @@
+package com.deulbull.performance.domain.band.web.controller;
+
+import com.deulbull.performance.domain.band.service.PersonService;
+import com.deulbull.performance.domain.band.web.dto.PersonRequestDto;
+import com.deulbull.performance.domain.band.web.dto.PersonResponseDto;
+import com.deulbull.performance.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/persons")
+@RequiredArgsConstructor
+public class PersonController {
+
+    private final PersonService personService;
+
+    // 여러 명의 Person 생성 API
+    @PostMapping
+    public SuccessResponse<List<PersonResponseDto>> createPersons(
+            @Valid @RequestBody List<PersonRequestDto> requestDtos
+    ) {
+        List<PersonResponseDto> responses = personService.createPersons(requestDtos);
+        return SuccessResponse.created(responses);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/band/web/dto/BandRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/dto/BandRequestDto.java
@@ -1,0 +1,11 @@
+package com.deulbull.performance.domain.band.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BandRequestDto(
+        @NotBlank(message = "밴드 이름은 필수 입력 항목입니다.")
+        String bandName,
+
+        String logoUrl
+) {
+}

--- a/src/main/java/com/deulbull/performance/domain/band/web/dto/BandRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/dto/BandRequestDto.java
@@ -1,11 +1,11 @@
 package com.deulbull.performance.domain.band.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
 
 public record BandRequestDto(
         @NotBlank(message = "밴드 이름은 필수 입력 항목입니다.")
         String bandName,
+        MultipartFile logoImage
+) { }
 
-        String logoUrl
-) {
-}

--- a/src/main/java/com/deulbull/performance/domain/band/web/dto/BandResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/dto/BandResponseDto.java
@@ -1,0 +1,23 @@
+package com.deulbull.performance.domain.band.web.dto;
+
+import com.deulbull.performance.domain.band.entity.Band;
+import lombok.Builder;
+
+@Builder
+public record BandResponseDto(
+        Long id,
+        String bandName,
+        String logoUrl,
+        String createdAt,
+        String updatedAt
+) {
+    public static BandResponseDto from(Band band) {
+        return BandResponseDto.builder()
+                .id(band.getId())
+                .bandName(band.getBandName())
+                .logoUrl(band.getLogoUrl())
+                .createdAt(band.formatDateTimeWithDay(band.getCreatedAt()))
+                .updatedAt(band.formatDateTimeWithDay(band.getUpdatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/band/web/dto/PersonRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/dto/PersonRequestDto.java
@@ -1,0 +1,13 @@
+package com.deulbull.performance.domain.band.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PersonRequestDto(
+        String studentId,
+
+        @NotBlank(message = "이름은 필수 입력 항목입니다.")
+        String name,
+
+        String instagramId
+) {
+}

--- a/src/main/java/com/deulbull/performance/domain/band/web/dto/PersonResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/band/web/dto/PersonResponseDto.java
@@ -1,0 +1,27 @@
+package com.deulbull.performance.domain.band.web.dto;
+
+import com.deulbull.performance.domain.band.entity.Person;
+import lombok.Builder;
+
+@Builder
+public record PersonResponseDto(
+        Long id,
+        String studentId,
+        String name,
+        String phoneNumber,
+        String instagramId,
+        String createdAt,
+        String updatedAt
+) {
+    public static PersonResponseDto from(Person person) {
+        return PersonResponseDto.builder()
+                .id(person.getId())
+                .studentId(person.getStudentId())
+                .name(person.getName())
+                .phoneNumber(person.getPhoneNumber())
+                .instagramId(person.getInstagramId())
+                .createdAt(person.formatDateTimeWithDay(person.getCreatedAt()))
+                .updatedAt(person.formatDateTimeWithDay(person.getUpdatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
@@ -1,9 +1,13 @@
 package com.deulbull.performance.domain.performance.service;
 
+import com.deulbull.performance.domain.performance.web.dto.PerformanceCreateRequestDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
 
 public interface PerformanceService {
+    // 공연 생성
+    PerformanceDetailResponseDto createPerformance(PerformanceCreateRequestDto requestDto);
+
     // 공연 정보 상세 조회
     PerformanceDetailResponseDto getPerformanceDetail(Long performanceId);
 

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -2,19 +2,24 @@ package com.deulbull.performance.domain.performance.service;
 
 import com.deulbull.performance.domain.performance.entity.Performance;
 import com.deulbull.performance.domain.performance.entity.PerformanceImage;
+import com.deulbull.performance.domain.performance.entity.PerformanceMoreLink;
 import com.deulbull.performance.domain.performance.exception.PerformanceNotFoundException;
 import com.deulbull.performance.domain.performance.repository.PerformanceImageRepository;
 import com.deulbull.performance.domain.performance.repository.PerformanceMoreLinkRepository;
 import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceCreateRequestDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto.MoreLinkDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse.PerformanceSetListDetail;
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
+import com.deulbull.performance.domain.song.entity.Song;
 import com.deulbull.performance.domain.song.exception.SongNotFoundException;
+import com.deulbull.performance.domain.song.repository.SongRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,6 +32,96 @@ public class PerformanceServiceImpl implements PerformanceService {
     private final PerformanceImageRepository performanceImageRepository;
     private final PerformanceMoreLinkRepository performanceMoreLinkRepository;
     private final PerformanceSongsRepository performanceSongsRepository;
+    private final SongRepository songRepository;
+
+    @Override
+    @Transactional
+    public PerformanceDetailResponseDto createPerformance(PerformanceCreateRequestDto requestDto) {
+        // 1. Performance 엔티티 생성 및 저장
+        Performance performance = Performance.builder()
+                .websiteName(requestDto.websiteName())
+                .websiteDescription(requestDto.websiteDescription())
+                .title(requestDto.title())
+                .subtitle(requestDto.subtitle())
+                .description(requestDto.description())
+                .location(requestDto.location())
+                .venue(requestDto.venue())
+                .dateTime(requestDto.dateTime())
+                .preSaleFee(requestDto.preSaleFee())
+                .onSiteFee(requestDto.onSiteFee())
+                .preSaleEndTime(requestDto.preSaleEndTime())
+                .posterFrontUrl(requestDto.posterFrontUrl())
+                .posterBackUrl(requestDto.posterBackUrl())
+                .openchatUrl(requestDto.openchatUrl())
+                .currentSong(null) // 초기에는 현재 곡 없음
+                .build();
+
+        performanceRepository.save(performance);
+
+        // 2. PerformanceImage 생성 및 저장
+        if (requestDto.imageUrls() != null && !requestDto.imageUrls().isEmpty()) {
+            List<PerformanceImage> images = requestDto.imageUrls().stream()
+                    .map(url -> PerformanceImage.builder()
+                            .imageUrl(url)
+                            .performance(performance)
+                            .build())
+                    .toList();
+            performanceImageRepository.saveAll(images);
+        }
+
+        // 3. PerformanceMoreLink 생성 및 저장
+        if (requestDto.moreLinks() != null && !requestDto.moreLinks().isEmpty()) {
+            List<PerformanceMoreLink> moreLinks = requestDto.moreLinks().stream()
+                    .map(dto -> PerformanceMoreLink.builder()
+                            .name(dto.name())
+                            .type(dto.type())
+                            .url(dto.url())
+                            .performance(performance)
+                            .build())
+                    .toList();
+            performanceMoreLinkRepository.saveAll(moreLinks);
+        }
+
+        // 4. Song 및 PerformanceSong 생성
+        if (requestDto.setlist() != null && !requestDto.setlist().isEmpty()) {
+            List<PerformanceSong> performanceSongs = requestDto.setlist().stream()
+                    .map(psDto -> {
+                        // 4-1. 곡 중복 체크 (title + artist)
+                        Song song = songRepository.findByTitleAndArtist(
+                                        psDto.song().title(),
+                                        psDto.song().artist()
+                                )
+                                .orElseGet(() -> {
+                                    // 4-2. 곡이 없으면 새로 생성
+                                    Song newSong = Song.builder()
+                                            .title(psDto.song().title())
+                                            .artist(psDto.song().artist())
+                                            .album(psDto.song().album())
+                                            .releaseDate(psDto.song().releaseDate())
+                                            .genre(psDto.song().genre())
+                                            .youtubeUrl(psDto.song().youtubeUrl())
+                                            .albumImgUrl(psDto.song().albumImgUrl())
+                                            .lyrics(psDto.song().lyrics())
+                                            .build();
+                                    return songRepository.save(newSong);
+                                });
+
+                        // 4-3. PerformanceSong 생성
+                        return PerformanceSong.builder()
+                                .orderInPerformance(psDto.orderInPerformance())
+                                .likes(0) // 초기 좋아요 수 0
+                                .performance(performance)
+                                .song(song)
+                                .build();
+                    })
+                    .toList();
+
+            performanceSongsRepository.saveAll(performanceSongs);
+        }
+
+        // 5. 생성된 공연 상세 정보 반환
+        return getPerformanceDetail(performance.getId());
+    }
 
     @Override
     public PerformanceDetailResponseDto getPerformanceDetail(Long performanceId) {

--- a/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
@@ -1,9 +1,11 @@
 package com.deulbull.performance.domain.performance.web.controller;
 
 import com.deulbull.performance.domain.performance.service.PerformanceService;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceCreateRequestDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
 import com.deulbull.performance.global.response.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +17,15 @@ import java.util.List;
 public class PerformanceController {
 
     private final PerformanceService performanceService;
+
+    // 공연 생성 API
+    @PostMapping
+    public SuccessResponse<PerformanceDetailResponseDto> createPerformance(
+            @Valid @RequestBody PerformanceCreateRequestDto requestDto
+    ) {
+        PerformanceDetailResponseDto response = performanceService.createPerformance(requestDto);
+        return SuccessResponse.created(response);
+    }
 
     // 공연 상세 조회
     @GetMapping("/{performanceId}")

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
@@ -1,0 +1,105 @@
+package com.deulbull.performance.domain.performance.web.dto;
+
+import com.deulbull.performance.domain.performance.entity.enums.LinkType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PerformanceCreateRequestDto(
+        // Performance 기본 정보
+        @NotBlank(message = "웹사이트 이름은 필수 입력 항목입니다.")
+        String websiteName,
+
+        String websiteDescription,
+
+        @NotBlank(message = "공연 제목은 필수 입력 항목입니다.")
+        String title,
+
+        String subtitle,
+
+        String description,
+
+        @NotBlank(message = "주소는 필수 입력 항목입니다.")
+        String location,
+
+        @NotBlank(message = "공연장 이름은 필수 입력 항목입니다.")
+        String venue,
+
+        @NotNull(message = "공연 날짜와 시간은 필수 입력 항목입니다.")
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime dateTime,
+
+        Integer preSaleFee,
+
+        Integer onSiteFee,
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime preSaleEndTime,
+
+        String posterFrontUrl,
+
+        String posterBackUrl,
+
+        String openchatUrl,
+
+        // PerformanceImage 리스트
+        List<String> imageUrls,
+
+        // PerformanceMoreLink 리스트
+        @Valid
+        List<MoreLinkCreateDto> moreLinks,
+
+        // PerformanceSong 리스트 (곡 정보 포함)
+        @Valid
+        @NotNull(message = "셋리스트는 필수 입력 항목입니다.")
+        List<PerformanceSongCreateDto> setlist
+) {
+    // 추가 링크 DTO
+    public record MoreLinkCreateDto(
+            @NotBlank(message = "링크 이름은 필수 입력 항목입니다.")
+            String name,
+
+            @NotNull(message = "링크 타입은 필수 입력 항목입니다.")
+            LinkType type,
+
+            @NotBlank(message = "링크 URL은 필수 입력 항목입니다.")
+            String url
+    ) {}
+
+    // 공연별 곡 정보 DTO
+    public record PerformanceSongCreateDto(
+            @NotNull(message = "곡 순서는 필수 입력 항목입니다.")
+            Integer orderInPerformance,
+
+            @Valid
+            @NotNull(message = "곡 정보는 필수 입력 항목입니다.")
+            SongCreateDto song
+    ) {}
+
+    // 곡 정보 DTO
+    public record SongCreateDto(
+            @NotBlank(message = "곡 제목은 필수 입력 항목입니다.")
+            String title,
+
+            @NotBlank(message = "아티스트는 필수 입력 항목입니다.")
+            String artist,
+
+            String album,
+
+            @JsonFormat(pattern = "yyyy-MM-dd")
+            LocalDate releaseDate,
+
+            String genre,
+
+            String youtubeUrl,
+
+            String albumImgUrl,
+
+            String lyrics
+    ) {}
+}

--- a/src/main/java/com/deulbull/performance/domain/song/repository/SongRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/song/repository/SongRepository.java
@@ -1,0 +1,13 @@
+package com.deulbull.performance.domain.song.repository;
+
+import com.deulbull.performance.domain.song.entity.Song;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SongRepository extends JpaRepository<Song, Long> {
+    // 곡 제목과 아티스트로 중복 체크
+    Optional<Song> findByTitleAndArtist(String title, String artist);
+}


### PR DESCRIPTION
## 연관 이슈
- close #50 

## 작업 내용
### 1. 밴드 생성 API
- `POST /api/bands` - 밴드 생성 (밴드명, 로고 URL)
- Service, Repository, DTO 구현
> 201 
<img width="420" height="351" alt="image" src="https://github.com/user-attachments/assets/ba667f3d-e43c-40d7-99a5-00e22c77fa97" />


### 2. Person (밴드 부원) 생성 API
- `POST /api/persons` - 여러 명 일괄 등록 가능
- 필수값: 이름 
> 201
<img width="397" height="383" alt="image" src="https://github.com/user-attachments/assets/3e436b49-f51f-4a35-a6a5-17b715d44eba" />


### 3. 공연 생성 API
- `POST /api/performances` - 공연 및 모든 연관 데이터 생성
- **관련 테이블**: Performance, PerformanceImage, PerformanceMoreLink, Song, PerformanceSong
- **곡 자동 중복 체크**: title + artist 기준으로 기존 곡 재사용하도록 구현
- **트랜잭션 처리**: 전체 롤백 보장을 위한 트랜잭션 처리 완료
- SongRepository 생성
> 201
<img width="425" height="247" alt="image" src="https://github.com/user-attachments/assets/074b7deb-7d6e-4bab-a948-a296b00e209e" />


## 논의하고 싶은 내용
- 공연 생성 시 곡 중복 체크 기준(title + artist)이 적절한지 논의하면 좋을 것 같습니다.
- Person 생성 API를 리스트 방식으로 한 것이 적절한지 (단일 등록 API 추가 필요 여부)도 함께 논의해봐도 좋겠습니다.

## 기타
- 추후 S3 업로드 로직 구현 이후 밴드 생성, 공연 생성의 이미지 url 부분을 수정해주어야 합니다.
