### PR TITLE
fix(current): 현재 진행 중인 곡이 null인 경우 예외처리

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceErrorCode.java
@@ -5,13 +5,14 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import static com.deulbull.performance.global.constant.StaticValue.NOT_FOUND;
+import static com.deulbull.performance.global.constant.StaticValue.NO_CONTENT;
 
 @Getter
 @RequiredArgsConstructor
 public enum AdminPerformanceErrorCode implements BaseResponseCode {
     ADMIN_SONG_404_NOT_FOUND("ADMIN_SONG_404_NOT_FOUND", NOT_FOUND, "해당 공연에 등록된 곡이 없습니다."),
-    ADMIN_PERFORMANCE_404_NOT_FOUND("ADMIN_PERFORMANCE_404_NOT_FOUND", NOT_FOUND, "해당 공연의 ID가 없습니다.");
-
+    ADMIN_PERFORMANCE_404_NOT_FOUND("ADMIN_PERFORMANCE_404_NOT_FOUND", NOT_FOUND, "해당 공연의 ID가 없습니다."),
+    PERFORMANCE_SONG_204_NO_CONTENT("PERFORMANCE_SONG_204_NO_CONTENT", NO_CONTENT,"아직 공연 시작 전 입니다.");
     private final String code;
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/deulbull/performance/domain/admin/exception/PerformanceSongNoContentException.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/PerformanceSongNoContentException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class PerformanceSongNoContentException extends BaseException {
+    public PerformanceSongNoContentException() {
+        super(AdminPerformanceErrorCode.PERFORMANCE_SONG_204_NO_CONTENT);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
@@ -4,6 +4,7 @@ import com.deulbull.performance.domain.admin.entity.Admin;
 import com.deulbull.performance.domain.admin.exception.AdminNotFoundException;
 import com.deulbull.performance.domain.admin.exception.AdminPerformanceNotFoundException;
 import com.deulbull.performance.domain.admin.exception.AdminSongNotFoundException;
+import com.deulbull.performance.domain.admin.exception.PerformanceSongNoContentException;
 import com.deulbull.performance.domain.admin.repository.AdminPerformanceRepository;
 import com.deulbull.performance.domain.admin.repository.AdminRepository;
 import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
@@ -28,7 +29,20 @@ public class AdminPerformanceServiceImpl implements AdminPerformanceService {
     public AdminCurrentSongResponseDto getCurrentSong(Long adminId) {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(AdminNotFoundException::new);
-        CurrentSongProjection currentSong = adminPerformanceRepository.findCurrentSongDtoByAdminId(admin.getId()).orElseThrow(AdminNotFoundException::new);
+
+        Performance performance = admin.getPerformance();
+        if (performance == null) {
+            throw new AdminPerformanceNotFoundException();
+        }
+
+        if (performance.getCurrentSong() == null) {
+            throw new PerformanceSongNoContentException();
+        }
+
+        CurrentSongProjection currentSong = adminPerformanceRepository
+                .findCurrentSongDtoByAdminId(admin.getId())
+                .orElseThrow(AdminSongNotFoundException::new);
+
         return new AdminCurrentSongResponseDto(currentSong.getTitle(), currentSong.getArtist(), currentSong.getAlbumImgUrl());
     }
 


### PR DESCRIPTION
## 연관 이슈
- close #57 

## 작업 내용
- CurrentSong의 Id가 null인 경우 (공연 시작 전) 204_NO_CONTENT를 리턴하게 변경

## 논의하고 싶은 내용

## 공유하고 싶은 내용
- 204 NO CONTENT
- 
<img width="1078" height="842" alt="image" src="https://github.com/user-attachments/assets/f5d6ee02-22d2-4f5b-84de-ce785678ed81" />
- 204의 경우 body를 열어보지말라는 뜻임으로 아무것도 return 해주지않음
- front에서 httpCode로 204임을 확인하고 처리해야함
## 기타