### PR TITLE
bug(next/previous): 다음 곡, 이전 곡 호출 시 마지막/곡이 없는 경우 예외처리

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminPerformanceErrorCode.java
@@ -12,7 +12,10 @@ import static com.deulbull.performance.global.constant.StaticValue.NO_CONTENT;
 public enum AdminPerformanceErrorCode implements BaseResponseCode {
     ADMIN_SONG_404_NOT_FOUND("ADMIN_SONG_404_NOT_FOUND", NOT_FOUND, "해당 공연에 등록된 곡이 없습니다."),
     ADMIN_PERFORMANCE_404_NOT_FOUND("ADMIN_PERFORMANCE_404_NOT_FOUND", NOT_FOUND, "해당 공연의 ID가 없습니다."),
+    PERFORMANCE_NEXT_SONG_404_NOT_FOUND("PERFORMANCE_NEXT_SONG_404_NOT_FOUND", NOT_FOUND, "해당 곡이 마지막 곡입니다."),
+    PERFORMANCE_PREVIOUS_SONG_404_NOT_FOUND("PERFORMANCE_PREVIOUS_SONG_404_NOT_FOUND", NOT_FOUND, "이전 곡을 찾을 수 없습니다."),
     PERFORMANCE_SONG_204_NO_CONTENT("PERFORMANCE_SONG_204_NO_CONTENT", NO_CONTENT,"아직 공연 시작 전 입니다.");
+
     private final String code;
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/deulbull/performance/domain/admin/exception/PerformanceNextSongNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/PerformanceNextSongNotFoundException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class PerformanceNextSongNotFoundException extends BaseException {
+    public PerformanceNextSongNotFoundException() {
+        super(AdminPerformanceErrorCode.PERFORMANCE_NEXT_SONG_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/exception/PerformancePreviousSongNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/PerformancePreviousSongNotFoundException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class PerformancePreviousSongNotFoundException extends BaseException {
+    public PerformancePreviousSongNotFoundException() {
+        super(AdminPerformanceErrorCode.PERFORMANCE_PREVIOUS_SONG_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
@@ -1,10 +1,7 @@
 package com.deulbull.performance.domain.admin.service;
 
 import com.deulbull.performance.domain.admin.entity.Admin;
-import com.deulbull.performance.domain.admin.exception.AdminNotFoundException;
-import com.deulbull.performance.domain.admin.exception.AdminPerformanceNotFoundException;
-import com.deulbull.performance.domain.admin.exception.AdminSongNotFoundException;
-import com.deulbull.performance.domain.admin.exception.PerformanceSongNoContentException;
+import com.deulbull.performance.domain.admin.exception.*;
 import com.deulbull.performance.domain.admin.repository.AdminPerformanceRepository;
 import com.deulbull.performance.domain.admin.repository.AdminRepository;
 import com.deulbull.performance.domain.admin.web.dto.AdminCurrentSongResponseDto;
@@ -63,13 +60,8 @@ public class AdminPerformanceServiceImpl implements AdminPerformanceService {
         if (current != null) {
             Integer currOrder = current.getOrderInPerformance();
             nextEntity = performanceSongsRepository
-                    .findFirstByPerformance_IdAndOrderInPerformanceGreaterThanOrderByOrderInPerformanceAsc(
-                            performanceId, currOrder
-                    )
-                    .orElseGet(() -> performanceSongsRepository
-                            .findFirstByPerformance_IdOrderByOrderInPerformanceAsc(performanceId)
-                            .orElseThrow(AdminSongNotFoundException::new)
-                    );
+                    .findFirstByPerformance_IdAndOrderInPerformanceGreaterThanOrderByOrderInPerformanceAsc(performanceId, currOrder)
+                    .orElseThrow(PerformanceNextSongNotFoundException::new);
         } else {
             nextEntity = performanceSongsRepository
                     .findFirstByPerformance_IdOrderByOrderInPerformanceAsc(performanceId)
@@ -111,16 +103,14 @@ public class AdminPerformanceServiceImpl implements AdminPerformanceService {
                     .findFirstByPerformance_IdAndOrderInPerformanceLessThanOrderByOrderInPerformanceDesc(
                             performanceId, currOrder
                     )
-                    .orElseGet(() ->
-                            performanceSongsRepository
-                                    .findFirstByPerformance_IdOrderByOrderInPerformanceDesc(performanceId)
-                                    .orElseThrow(AdminSongNotFoundException::new)
-                    );
+                    .orElseGet(() -> {
+                        performance.setCurrentSong(null);
+                        performanceRepository.saveAndFlush(performance);
+                        throw new PerformanceSongNoContentException();
+                    });
         } else {
-            // 현재곡이 비어있다면 마지막 곡을 현재곡으로 시작
-            prevEntity = performanceSongsRepository
-                    .findFirstByPerformance_IdOrderByOrderInPerformanceDesc(performanceId)
-                    .orElseThrow(AdminSongNotFoundException::new);
+            // 현재곡이 비어있다면 이전 곡을 찾지 못함 404 ERROR return
+            throw new PerformancePreviousSongNotFoundException();
         }
 
         // current_song 갱신


### PR DESCRIPTION
## 연관 이슈
- close #59 

## 작업 내용
- 현재 곡이 마지막 곡일 경우 다음 곡이 없다는 404 NOT FOUND 처리
- 현재 곡이 null일 경우 (공연 시작 전) 이전 곡이 없다는 404 NOT FOUND 처리

## 논의하고 싶은 내용

## 공유하고 싶은 내용
- 현재 곡이 null인 경우
- 
<img width="1060" height="776" alt="image" src="https://github.com/user-attachments/assets/26335e12-d415-453c-84c6-f49b8052197e" />
- 현재 곡이 마지막인 경우 
- 
<img width="1070" height="834" alt="image" src="https://github.com/user-attachments/assets/129a2834-cb8f-4f8b-866a-5bfcebeb49f5" />
- 첫번쨰 곡에서 이전 곡 api 호출 시 204 return (공연 시작 전과 동일한 상태)
- 
<img width="1070" height="842" alt="image" src="https://github.com/user-attachments/assets/e061b922-46cb-49b2-b16b-74e14a352599" />

