### PR TITLE
feat(S3): S3 연결 및 공연 생성 api 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	// CoolSMS
 	implementation 'net.nurigo:sdk:4.2.7'
 
+	// AWS
+	implementation platform("software.amazon.awssdk:bom:2.25.70")
+	implementation "software.amazon.awssdk:s3"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
@@ -3,10 +3,17 @@ package com.deulbull.performance.domain.performance.service;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceCreateRequestDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface PerformanceService {
     // 공연 생성
-    PerformanceDetailResponseDto createPerformance(PerformanceCreateRequestDto requestDto);
+    PerformanceDetailResponseDto createPerformance(
+            PerformanceCreateRequestDto requestDto,
+            MultipartFile posterFront,
+            MultipartFile posterBack,
+            List<MultipartFile> images);
 
     // 공연 정보 상세 조회
     PerformanceDetailResponseDto getPerformanceDetail(Long performanceId);

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -17,9 +17,11 @@ import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSo
 import com.deulbull.performance.domain.song.entity.Song;
 import com.deulbull.performance.domain.song.exception.SongNotFoundException;
 import com.deulbull.performance.domain.song.repository.SongRepository;
+import com.deulbull.performance.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -28,15 +30,22 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class PerformanceServiceImpl implements PerformanceService {
+
     private final PerformanceRepository performanceRepository;
     private final PerformanceImageRepository performanceImageRepository;
     private final PerformanceMoreLinkRepository performanceMoreLinkRepository;
     private final PerformanceSongsRepository performanceSongsRepository;
     private final SongRepository songRepository;
+    private final S3Uploader s3Uploader;
 
     @Override
     @Transactional
-    public PerformanceDetailResponseDto createPerformance(PerformanceCreateRequestDto requestDto) {
+    public PerformanceDetailResponseDto createPerformance(
+            PerformanceCreateRequestDto requestDto,
+            MultipartFile posterFront,
+            MultipartFile posterBack,
+            List<MultipartFile> images) {
+
         // 1. Performance 엔티티 생성 및 저장
         Performance performance = Performance.builder()
                 .websiteName(requestDto.websiteName())
@@ -50,26 +59,59 @@ public class PerformanceServiceImpl implements PerformanceService {
                 .preSaleFee(requestDto.preSaleFee())
                 .onSiteFee(requestDto.onSiteFee())
                 .preSaleEndTime(requestDto.preSaleEndTime())
-                .posterFrontUrl(requestDto.posterFrontUrl())
-                .posterBackUrl(requestDto.posterBackUrl())
+                .posterFrontUrl(null)
+                .posterBackUrl(null)
                 .openchatUrl(requestDto.openchatUrl())
                 .currentSong(null) // 초기에는 현재 곡 없음
                 .build();
 
         performanceRepository.save(performance);
 
-        // 2. PerformanceImage 생성 및 저장
-        if (requestDto.imageUrls() != null && !requestDto.imageUrls().isEmpty()) {
-            List<PerformanceImage> images = requestDto.imageUrls().stream()
-                    .map(url -> PerformanceImage.builder()
-                            .imageUrl(url)
-                            .performance(performance)
-                            .build())
-                    .toList();
-            performanceImageRepository.saveAll(images);
+        Long performanceId = performance.getId();
+
+        // 2. S3에 포스터 업로드
+        String posterFrontUrl = null;
+        String posterBackUrl = null;
+
+        if (posterFront != null && !posterFront.isEmpty()) {
+            posterFrontUrl = s3Uploader.upload(
+                    posterFront,
+                    "performance/" + performanceId + "/poster-front"
+            );
+        }
+        if (posterBack != null && !posterBack.isEmpty()) {
+            posterBackUrl = s3Uploader.upload(
+                    posterBack,
+                    "performance/" + performanceId + "/poster-back"
+            );
         }
 
-        // 3. PerformanceMoreLink 생성 및 저장
+        // 3. 공연 이미지 S3 업로드 + PerformanceImage 저장
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null && !images.isEmpty()) {
+            int index = 1;
+            for (MultipartFile image : images) {
+                if (image == null || image.isEmpty()) continue;
+
+                String url = s3Uploader.upload(
+                        image,
+                        "performance/" + performanceId + "/image" + index++
+                );
+                imageUrls.add(url);
+            }
+
+            if (!imageUrls.isEmpty()) {
+                List<PerformanceImage> performanceImages = imageUrls.stream()
+                        .map(url -> PerformanceImage.builder()
+                                .imageUrl(url)
+                                .performance(performance)
+                                .build())
+                        .toList();
+                performanceImageRepository.saveAll(performanceImages);
+            }
+        }
+
+        // 4. PerformanceMoreLink 생성 및 저장
         if (requestDto.moreLinks() != null && !requestDto.moreLinks().isEmpty()) {
             List<PerformanceMoreLink> moreLinks = requestDto.moreLinks().stream()
                     .map(dto -> PerformanceMoreLink.builder()
@@ -82,17 +124,17 @@ public class PerformanceServiceImpl implements PerformanceService {
             performanceMoreLinkRepository.saveAll(moreLinks);
         }
 
-        // 4. Song 및 PerformanceSong 생성
+        // 5. Song 및 PerformanceSong 생성
         if (requestDto.setlist() != null && !requestDto.setlist().isEmpty()) {
             List<PerformanceSong> performanceSongs = requestDto.setlist().stream()
                     .map(psDto -> {
-                        // 4-1. 곡 중복 체크 (title + artist)
+                        // 5-1. 곡 중복 체크 (title + artist)
                         Song song = songRepository.findByTitleAndArtist(
                                         psDto.song().title(),
                                         psDto.song().artist()
                                 )
                                 .orElseGet(() -> {
-                                    // 4-2. 곡이 없으면 새로 생성
+                                    // 5-2. 곡이 없으면 새로 생성
                                     Song newSong = Song.builder()
                                             .title(psDto.song().title())
                                             .artist(psDto.song().artist())
@@ -106,7 +148,7 @@ public class PerformanceServiceImpl implements PerformanceService {
                                     return songRepository.save(newSong);
                                 });
 
-                        // 4-3. PerformanceSong 생성
+                        // 5-3. PerformanceSong 생성
                         return PerformanceSong.builder()
                                 .orderInPerformance(psDto.orderInPerformance())
                                 .likes(0) // 초기 좋아요 수 0
@@ -118,8 +160,11 @@ public class PerformanceServiceImpl implements PerformanceService {
 
             performanceSongsRepository.saveAll(performanceSongs);
         }
+        // 6. Performance 엔티티에 포스터 URL 반영
+        performance.setPosterFrontUrl(posterFrontUrl);
+        performance.setPosterBackUrl(posterBackUrl);
 
-        // 5. 생성된 공연 상세 정보 반환
+        // 7. 생성된 공연 상세 정보 반환
         return getPerformanceDetail(performance.getId());
     }
 

--- a/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
@@ -8,6 +8,7 @@ import com.deulbull.performance.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -19,11 +20,14 @@ public class PerformanceController {
     private final PerformanceService performanceService;
 
     // 공연 생성 API
-    @PostMapping
+    @PostMapping(consumes = {"multipart/form-data"})
     public SuccessResponse<PerformanceDetailResponseDto> createPerformance(
-            @Valid @RequestBody PerformanceCreateRequestDto requestDto
+            @Valid @RequestPart PerformanceCreateRequestDto requestDto,
+            @RequestPart("posterFront") MultipartFile posterFront,
+            @RequestPart(value = "posterBack", required = false) MultipartFile posterBack,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
-        PerformanceDetailResponseDto response = performanceService.createPerformance(requestDto);
+        PerformanceDetailResponseDto response = performanceService.createPerformance(requestDto, posterFront, posterBack, images);
         return SuccessResponse.created(response);
     }
 

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
@@ -41,14 +41,7 @@ public record PerformanceCreateRequestDto(
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime preSaleEndTime,
 
-        String posterFrontUrl,
-
-        String posterBackUrl,
-
         String openchatUrl,
-
-        // PerformanceImage 리스트
-        List<String> imageUrls,
 
         // PerformanceMoreLink 리스트
         @Valid

--- a/src/main/java/com/deulbull/performance/global/config/AwsS3Config.java
+++ b/src/main/java/com/deulbull/performance/global/config/AwsS3Config.java
@@ -1,0 +1,23 @@
+package com.deulbull.performance.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
+++ b/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
@@ -1,0 +1,49 @@
+package com.deulbull.performance.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile file, String keyPrefix) {
+        String ext = getExtension(file.getOriginalFilename());
+        String key = keyPrefix + "-" + UUID.randomUUID() + "." + ext;
+
+        try {
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .contentType(file.getContentType())
+                            .build(),
+                    RequestBody.fromBytes(file.getBytes())
+            );
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+
+        return "https://" + bucket + ".s3.amazonaws.com/" + key;
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null) return "dat";
+        int idx = filename.lastIndexOf('.');
+        if (idx == -1) return "dat";
+        return filename.substring(idx + 1);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- close #51 

## 작업 내용
- S3연결을 위한 종속성 추가
- S3config로 S3Client bean 주입
- S3Uploader로 S3에 업로드 기능 생성
- Dto를 S3에 맞춰 변경
- Controller에 MultiFile로 받아 이미지들 받는 방법으로 변경
- Service에 S3업로드 및 DB 저장 후 Dto양식에 맞춰 return으로 변경

## 공유하고 싶은 내용
- 201 Created
- 
<img width="1078" height="837" alt="image" src="https://github.com/user-attachments/assets/e4b60ed1-6a20-4200-b5cc-e6836c08fb49" />
