### PR TITLE
feat: Prometheus 및 Grafana 모니터링 시스템 구축

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI with Gradle"]
     types: [completed]
-    branches: [main]
+    branches: [develop, main]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy to Production Server
+    name: Deploy to Server
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,29 +30,43 @@ jobs:
           script: |
             set -e
 
-            cd /home/${{ secrets.SERVER_USER }}
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            if [ "$BRANCH" = "main" ]; then
+              NAME="deulbull"
+              PORT=8080
+              PROFILE="prod"
+              DDL_AUTO="none"
+            else
+              NAME="deulbull-dev"
+              PORT=8081
+              PROFILE="dev"
+              DDL_AUTO="update"
+            fi
 
-            # 환경 변수 파일 업데이트
-            cat > deulbull-prod.env << 'EOF'
+            # 환경 변수 파일 생성 (ENV_FILE에서 가져오되 DDL과 Profile 추가)
+            cat > /home/${{ secrets.SERVER_USER }}/${NAME}.env << 'EOF'
             ${{ secrets.ENV_FILE }}
             EOF
 
-            echo "SPRING_PROFILES_ACTIVE=prod" >> deulbull-prod.env
-            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=none" >> deulbull-prod.env
+            # DDL 설정과 Profile 추가
+            echo "SPRING_PROFILES_ACTIVE=${PROFILE}" >> /home/${{ secrets.SERVER_USER }}/${NAME}.env
+            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=${DDL_AUTO}" >> /home/${{ secrets.SERVER_USER }}/${NAME}.env
 
-            # Docker 로그인
             if [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
               echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             fi
 
-            echo "[1/4] Pull latest image..."
+            echo "[1/3] Pull latest image..."
             docker pull ${{ env.IMAGE }}:latest
 
-            echo "[2/4] Restart Spring app..."
-            docker-compose up -d --no-deps deulbull-prod
+            echo "[2/3] Restart container..."
+            docker stop $NAME || true
+            docker rm $NAME || true
+            docker run -d --name $NAME \
+              --env-file /home/${{ secrets.SERVER_USER }}/${NAME}.env \
+              -p ${PORT}:8080 \
+              --restart always \
+              ${{ env.IMAGE }}:latest
 
-            echo "[3/4] Check status..."
-            docker-compose ps
-
-            echo "[4/4] Cleanup..."
+            echo "[3/3] Cleanup..."
             docker image prune -f

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI with Gradle"]
     types: [completed]
-    branches: [main]
+    branches: [develop, main]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy to Production Server
+    name: Deploy to Server
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,15 +30,27 @@ jobs:
           script: |
             set -e
 
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            if [ "$BRANCH" = "main" ]; then
+              NAME="deulbull-prod"
+              PROFILE="prod"
+              DDL_AUTO="none"
+            else
+              NAME="deulbull-dev"
+              PROFILE="dev"
+              DDL_AUTO="update"
+            fi
+
             cd /home/${{ secrets.SERVER_USER }}
 
-            # 환경 변수 파일 업데이트
-            cat > deulbull-prod.env << 'EOF'
+            # 환경 변수 파일 생성
+            cat > ${NAME}.env << 'EOF'
             ${{ secrets.ENV_FILE }}
             EOF
 
-            echo "SPRING_PROFILES_ACTIVE=prod" >> deulbull-prod.env
-            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=none" >> deulbull-prod.env
+            # DDL 설정과 Profile 추가
+            echo "SPRING_PROFILES_ACTIVE=${PROFILE}" >> ${NAME}.env
+            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=${DDL_AUTO}" >> ${NAME}.env
 
             # Docker 로그인
             if [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
@@ -49,7 +61,7 @@ jobs:
             docker pull ${{ env.IMAGE }}:latest
 
             echo "[2/4] Restart Spring app..."
-            docker-compose up -d --no-deps deulbull-prod
+            docker-compose up -d --no-deps ${NAME}
 
             echo "[3/4] Check status..."
             docker-compose ps

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI with Gradle"]
     types: [completed]
-    branches: [develop, main]
+    branches: [main]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy to Server
+    name: Deploy to Production Server
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,43 +30,29 @@ jobs:
           script: |
             set -e
 
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
-            if [ "$BRANCH" = "main" ]; then
-              NAME="deulbull"
-              PORT=8080
-              PROFILE="prod"
-              DDL_AUTO="none"
-            else
-              NAME="deulbull-dev"
-              PORT=8081
-              PROFILE="dev"
-              DDL_AUTO="update"
-            fi
+            cd /home/${{ secrets.SERVER_USER }}
 
-            # 환경 변수 파일 생성 (ENV_FILE에서 가져오되 DDL과 Profile 추가)
-            cat > /home/${{ secrets.SERVER_USER }}/${NAME}.env << 'EOF'
+            # 환경 변수 파일 업데이트
+            cat > deulbull-prod.env << 'EOF'
             ${{ secrets.ENV_FILE }}
             EOF
 
-            # DDL 설정과 Profile 추가
-            echo "SPRING_PROFILES_ACTIVE=${PROFILE}" >> /home/${{ secrets.SERVER_USER }}/${NAME}.env
-            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=${DDL_AUTO}" >> /home/${{ secrets.SERVER_USER }}/${NAME}.env
+            echo "SPRING_PROFILES_ACTIVE=prod" >> deulbull-prod.env
+            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=none" >> deulbull-prod.env
 
+            # Docker 로그인
             if [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
               echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             fi
 
-            echo "[1/3] Pull latest image..."
+            echo "[1/4] Pull latest image..."
             docker pull ${{ env.IMAGE }}:latest
 
-            echo "[2/3] Restart container..."
-            docker stop $NAME || true
-            docker rm $NAME || true
-            docker run -d --name $NAME \
-              --env-file /home/${{ secrets.SERVER_USER }}/${NAME}.env \
-              -p ${PORT}:8080 \
-              --restart always \
-              ${{ env.IMAGE }}:latest
+            echo "[2/4] Restart Spring app..."
+            docker-compose up -d --no-deps deulbull-prod
 
-            echo "[3/3] Cleanup..."
+            echo "[3/4] Check status..."
+            docker-compose ps
+
+            echo "[4/4] Cleanup..."
             docker image prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	// Actuator & Prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	// mysql
 	implementation 'com.mysql:mysql-connector-j'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,16 @@ spring:
 server:
   servlet:
     context-path: /api
+
+# Actuator & Prometheus
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## 연관 이슈
- close #64

## 작업 내용
- Spring Boot Actuator 및 Prometheus 메트릭 수집 설정 추가
- Docker Compose 기반 배포 환경 구성 (Spring + Prometheus + Grafana)
- CD 워크플로우를 `docker run`에서 `docker-compose`로 전환
- Nginx 리버스 프록시를 통한 모니터링 도구 접근 경로 설정

## 주요 변경사항
**Spring Boot**
- Actuator, Micrometer Prometheus 의존성 추가
- `/api/actuator/prometheus` 엔드포인트 노출

**배포 환경**
- Docker Compose로 Spring, Prometheus, Grafana 통합 관리
- develop, main 브랜치 모두 자동 배포 지원
- 컨테이너별 독립적 재시작 가능 (`--no-deps` 옵션)

**모니터링 접근**
- Grafana: `https://52.79.69.64.nip.io/grafana/`
- Prometheus: `https://52.79.69.64.nip.io/prometheus/`
<img width="1066" height="588" alt="image" src="https://github.com/user-attachments/assets/1095a73e-7c51-446c-8da7-caea20695248" />
