### PR TITLE
fix(config): Actuator 엔드포인트 Spring Security 허용

### DIFF
--- a/src/main/java/com/deulbull/performance/global/config/SecurityConfig.java
+++ b/src/main/java/com/deulbull/performance/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**").permitAll() 
                         .requestMatchers("/api/admin/auth/login", "/api/admin/auth/signup").permitAll()
                         .requestMatchers("/api/admin/**").authenticated()
                         .requestMatchers("/api/**").permitAll()


### PR DESCRIPTION
## 연관 이슈
- close #64 

## 작업 내용
- Spring Security에서 `/actuator/**` 엔드포인트 허용 설정 추가
- Prometheus가 `/api/actuator/prometheus`에 접근 가능하도록 수정

## 논의하고 싶은 내용
- 없음

## 공유하고 싶은 내용
- 없음

## 기타
- 없음