### PR TITLE
fix(cd): docker compose 사이 하이픈 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,10 +61,10 @@ jobs:
             docker pull ${{ env.IMAGE }}:latest
 
             echo "[2/4] Restart Spring app..."
-            docker-compose up -d --no-deps ${NAME}
+            docker compose up -d --no-deps ${NAME}
 
             echo "[3/4] Check status..."
-            docker-compose ps
+            docker compose ps
 
             echo "[4/4] Cleanup..."
             docker image prune -f


### PR DESCRIPTION
## 연관 이슈
- close #64

## 작업 내용
- CD 워크플로우에서 `docker-compose` 명령어를 `docker compose`로 변경
- Docker Compose V2 호환성 개선

## 논의하고 싶은 내용
- 없음

## 공유하고 싶은 내용
- 구 버전 `docker-compose` (V1)는 최신 Docker 이미지와 호환 문제 발생
- `docker compose` (V2)로 변경하여 안정성 확보

## 기타
- 없음