### PR TITLE
fix(cd): 컨테이너 충돌 방지를 위한 기존 컨테이너 제거 로직 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,7 @@ jobs:
             docker pull ${{ env.IMAGE }}:latest
 
             echo "[2/4] Restart Spring app..."
+            docker compose rm -f ${NAME} || true
             docker compose up -d --no-deps ${NAME}
 
             echo "[3/4] Check status..."


### PR DESCRIPTION
## 연관 이슈
- close #69 

## 작업 내용
- CD 워크플로우에 `docker compose rm -f` 명령어 추가하여 기존 컨테이너 강제 제거
- 컨테이너 재시작 시 충돌 방지 로직 구현

## 논의하고 싶은 내용
- 없음

## 공유하고 싶은 내용
- `docker compose rm -f`로 기존 컨테이너를 안전하게 제거 후 재시작

## 기타
- 없음