### PR TITLE
feat: 사전 예매 정보 조회 API 필드 추가 및 셋리스트 멤버 정보 저장 기능 구현

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/band/repository/PersonRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/band/repository/PersonRepository.java
@@ -4,6 +4,9 @@ import com.deulbull.performance.domain.band.entity.Person;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PersonRepository extends JpaRepository<Person, Long> {
+    Optional<Person> findByName(String name);
 }

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingService.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingService.java
@@ -2,14 +2,14 @@ package com.deulbull.performance.domain.booking.service;
 
 import com.deulbull.performance.domain.booking.web.dto.BookingRequestDto;
 import com.deulbull.performance.domain.booking.web.dto.BookingUpdateRequestDto;
-import com.deulbull.performance.domain.booking.web.dto.OpenChatUrlResponse;
+import com.deulbull.performance.domain.booking.web.dto.PreBookingInfoResponse;
 
 public interface BookingService {
     // 예매 생성
     void createBooking(Long performanceId, BookingRequestDto requestDto);
 
-    // 공연 문의링크 조회
-    OpenChatUrlResponse getOpenChatUrl(Long performanceId);
+    // 사전 예매 관련 정보 조회
+    PreBookingInfoResponse getPreBookingInfo(Long performanceId);
 
     // 예매 정보 수정
     void updateBooking(Long bookingId, BookingUpdateRequestDto requestDto);

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -7,7 +7,7 @@ import com.deulbull.performance.domain.booking.exception.OpenChatUrlNotFoundExce
 import com.deulbull.performance.domain.booking.repository.BookingRepository;
 import com.deulbull.performance.domain.booking.web.dto.BookingRequestDto;
 import com.deulbull.performance.domain.booking.web.dto.BookingUpdateRequestDto;
-import com.deulbull.performance.domain.booking.web.dto.OpenChatUrlResponse;
+import com.deulbull.performance.domain.booking.web.dto.PreBookingInfoResponse;
 import com.deulbull.performance.domain.performance.entity.Performance;
 import com.deulbull.performance.domain.performance.exception.PerformanceNotFoundException;
 import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
@@ -51,7 +51,7 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     @Transactional(readOnly = true)
-    public OpenChatUrlResponse getOpenChatUrl(Long performanceId) {
+    public PreBookingInfoResponse getPreBookingInfo(Long performanceId) {
         // 1. 공연 조회
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(PerformanceNotFoundException::new);
@@ -62,8 +62,16 @@ public class BookingServiceImpl implements BookingService {
             throw new OpenChatUrlNotFoundException();
         }
 
-        // 3. 응답 반환
-        return new OpenChatUrlResponse(openchatUrl);
+        // 3. 사전 예매 관련 정보 응답 반환
+        return new PreBookingInfoResponse(
+                openchatUrl,
+                performance.getPreSaleEndTime(),
+                performance.getPreSaleFee(),
+                performance.getOnSiteFee(),
+                performance.getBankAccount(),
+                performance.getKakaopayUrl(),
+                performance.getNaverpayUrl()
+        );
     }
 
     @Override

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -65,12 +65,14 @@ public class BookingServiceImpl implements BookingService {
         // 3. 사전 예매 관련 정보 응답 반환
         return new PreBookingInfoResponse(
                 openchatUrl,
-                performance.getPreSaleEndTime(),
-                performance.getPreSaleFee(),
-                performance.getOnSiteFee(),
-                performance.getBankAccount(),
-                performance.getKakaopayUrl(),
-                performance.getNaverpayUrl()
+                performance.getPreSaleEndTime() != null ? performance.getPreSaleEndTime().toString() : "",
+                performance.getPreSaleFee() != null ? performance.getPreSaleFee().toString() : "",
+                performance.getOnSiteFee() != null ? performance.getOnSiteFee().toString() : "",
+                performance.getBankName() != null ? performance.getBankName() : "",
+                performance.getBankAccount() != null ? performance.getBankAccount() : "",
+                performance.getAccountHolder() != null ? performance.getAccountHolder() : "",
+                performance.getKakaopayUrl() != null ? performance.getKakaopayUrl() : "",
+                performance.getNaverpayUrl() != null ? performance.getNaverpayUrl() : ""
         );
     }
 

--- a/src/main/java/com/deulbull/performance/domain/booking/web/controller/InquiryController.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/web/controller/InquiryController.java
@@ -1,7 +1,7 @@
 package com.deulbull.performance.domain.booking.web.controller;
 
 import com.deulbull.performance.domain.booking.service.BookingService;
-import com.deulbull.performance.domain.booking.web.dto.OpenChatUrlResponse;
+import com.deulbull.performance.domain.booking.web.dto.PreBookingInfoResponse;
 import com.deulbull.performance.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +14,12 @@ public class InquiryController {
 
     private final BookingService bookingService;
 
-    // 공연 문의링크 조회 API
+    // 사전 예매 관련 정보 조회 API
     @GetMapping("/inquiry")
-    public ResponseEntity<SuccessResponse<OpenChatUrlResponse>> getOpenChatUrl(
+    public ResponseEntity<SuccessResponse<PreBookingInfoResponse>> getPreBookingInfo(
             @PathVariable Long performanceId
     ) {
-        OpenChatUrlResponse response = bookingService.getOpenChatUrl(performanceId);
+        PreBookingInfoResponse response = bookingService.getPreBookingInfo(performanceId);
         return ResponseEntity.ok(SuccessResponse.ok(response));
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/booking/web/dto/OpenChatUrlResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/web/dto/OpenChatUrlResponse.java
@@ -1,6 +1,0 @@
-package com.deulbull.performance.domain.booking.web.dto;
-
-public record OpenChatUrlResponse(
-        String openChatUrl
-) {
-}

--- a/src/main/java/com/deulbull/performance/domain/booking/web/dto/PreBookingInfoResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/web/dto/PreBookingInfoResponse.java
@@ -1,13 +1,13 @@
 package com.deulbull.performance.domain.booking.web.dto;
 
-import java.time.LocalDateTime;
-
 public record PreBookingInfoResponse(
         String openChatUrl,
-        LocalDateTime preSaleEndTime,
-        Integer preSaleFee,
-        Integer onSiteFee,
+        String preSaleEndTime,
+        String preSaleFee,
+        String onSiteFee,
+        String bankName,
         String bankAccount,
+        String accountHolder,
         String kakaopayUrl,
         String naverpayUrl
 ) {

--- a/src/main/java/com/deulbull/performance/domain/booking/web/dto/PreBookingInfoResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/web/dto/PreBookingInfoResponse.java
@@ -1,0 +1,14 @@
+package com.deulbull.performance.domain.booking.web.dto;
+
+import java.time.LocalDateTime;
+
+public record PreBookingInfoResponse(
+        String openChatUrl,
+        LocalDateTime preSaleEndTime,
+        Integer preSaleFee,
+        Integer onSiteFee,
+        String bankAccount,
+        String kakaopayUrl,
+        String naverpayUrl
+) {
+}

--- a/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
@@ -31,6 +31,9 @@ public class Performance extends BaseEntity {
     private String posterFrontUrl; // 포스터 앞면 이미지 URL
     private String posterBackUrl;  // 포스터 뒷면 이미지 URL
     private String openchatUrl;
+    private String bankAccount; // 계좌 정보
+    private String kakaopayUrl; // 카카오페이 결제 URL
+    private String naverpayUrl; // 네이버페이 결제 URL
 
     @ManyToOne
     @JoinColumn(name = "current_song_id")

--- a/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
@@ -31,7 +31,9 @@ public class Performance extends BaseEntity {
     private String posterFrontUrl; // 포스터 앞면 이미지 URL
     private String posterBackUrl;  // 포스터 뒷면 이미지 URL
     private String openchatUrl;
-    private String bankAccount; // 계좌 정보
+    private String bankName; // 은행명
+    private String bankAccount; // 계좌번호
+    private String accountHolder; // 예금주
     private String kakaopayUrl; // 카카오페이 결제 URL
     private String naverpayUrl; // 네이버페이 결제 URL
 

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -1,5 +1,10 @@
 package com.deulbull.performance.domain.performance.service;
 
+import com.deulbull.performance.domain.band.entity.BandSession;
+import com.deulbull.performance.domain.band.entity.Person;
+import com.deulbull.performance.domain.band.entity.enums.SessionType;
+import com.deulbull.performance.domain.band.repository.BandSessionRepository;
+import com.deulbull.performance.domain.band.repository.PersonRepository;
 import com.deulbull.performance.domain.performance.entity.Performance;
 import com.deulbull.performance.domain.performance.entity.PerformanceImage;
 import com.deulbull.performance.domain.performance.entity.PerformanceMoreLink;
@@ -8,6 +13,7 @@ import com.deulbull.performance.domain.performance.repository.PerformanceImageRe
 import com.deulbull.performance.domain.performance.repository.PerformanceMoreLinkRepository;
 import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceCreateRequestDto;
+import com.deulbull.performance.domain.performance.web.dto.PerformanceCreateRequestDto.MembersDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceDetailResponseDto.MoreLinkDto;
 import com.deulbull.performance.domain.performance.web.dto.PerformanceSetlistResponse;
@@ -36,6 +42,8 @@ public class PerformanceServiceImpl implements PerformanceService {
     private final PerformanceMoreLinkRepository performanceMoreLinkRepository;
     private final PerformanceSongsRepository performanceSongsRepository;
     private final SongRepository songRepository;
+    private final PersonRepository personRepository;
+    private final BandSessionRepository bandSessionRepository;
     private final S3Uploader s3Uploader;
 
     @Override
@@ -62,6 +70,11 @@ public class PerformanceServiceImpl implements PerformanceService {
                 .posterFrontUrl(null)
                 .posterBackUrl(null)
                 .openchatUrl(requestDto.openchatUrl())
+                .bankName(requestDto.bankName())
+                .bankAccount(requestDto.bankAccount())
+                .accountHolder(requestDto.accountHolder())
+                .kakaopayUrl(requestDto.kakaopayUrl())
+                .naverpayUrl(requestDto.naverpayUrl())
                 .currentSong(null) // 초기에는 현재 곡 없음
                 .build();
 
@@ -126,39 +139,41 @@ public class PerformanceServiceImpl implements PerformanceService {
 
         // 5. Song 및 PerformanceSong 생성
         if (requestDto.setlist() != null && !requestDto.setlist().isEmpty()) {
-            List<PerformanceSong> performanceSongs = requestDto.setlist().stream()
-                    .map(psDto -> {
-                        // 5-1. 곡 중복 체크 (title + artist)
-                        Song song = songRepository.findByTitleAndArtist(
-                                        psDto.song().title(),
-                                        psDto.song().artist()
-                                )
-                                .orElseGet(() -> {
-                                    // 5-2. 곡이 없으면 새로 생성
-                                    Song newSong = Song.builder()
-                                            .title(psDto.song().title())
-                                            .artist(psDto.song().artist())
-                                            .album(psDto.song().album())
-                                            .releaseDate(psDto.song().releaseDate())
-                                            .genre(psDto.song().genre())
-                                            .youtubeUrl(psDto.song().youtubeUrl())
-                                            .albumImgUrl(psDto.song().albumImgUrl())
-                                            .lyrics(psDto.song().lyrics())
-                                            .build();
-                                    return songRepository.save(newSong);
-                                });
+            for (var psDto : requestDto.setlist()) {
+                // 5-1. 곡 중복 체크 (title + artist)
+                Song song = songRepository.findByTitleAndArtist(
+                                psDto.song().title(),
+                                psDto.song().artist()
+                        )
+                        .orElseGet(() -> {
+                            // 5-2. 곡이 없으면 새로 생성
+                            Song newSong = Song.builder()
+                                    .title(psDto.song().title())
+                                    .artist(psDto.song().artist())
+                                    .album(psDto.song().album())
+                                    .releaseDate(psDto.song().releaseDate())
+                                    .genre(psDto.song().genre())
+                                    .youtubeUrl(psDto.song().youtubeUrl())
+                                    .albumImgUrl(psDto.song().albumImgUrl())
+                                    .lyrics(psDto.song().lyrics())
+                                    .build();
+                            return songRepository.save(newSong);
+                        });
 
-                        // 5-3. PerformanceSong 생성
-                        return PerformanceSong.builder()
-                                .orderInPerformance(psDto.orderInPerformance())
-                                .likes(0) // 초기 좋아요 수 0
-                                .performance(performance)
-                                .song(song)
-                                .build();
-                    })
-                    .toList();
+                // 5-3. PerformanceSong 생성 및 저장
+                PerformanceSong performanceSong = PerformanceSong.builder()
+                        .orderInPerformance(psDto.orderInPerformance())
+                        .likes(0) // 초기 좋아요 수 0
+                        .performance(performance)
+                        .song(song)
+                        .build();
+                performanceSongsRepository.save(performanceSong);
 
-            performanceSongsRepository.saveAll(performanceSongs);
+                // 5-4. BandSession 생성 (members 정보 처리)
+                if (psDto.members() != null) {
+                    createBandSessions(performanceSong, psDto.members());
+                }
+            }
         }
         // 6. Performance 엔티티에 포스터 URL 반영
         performance.setPosterFrontUrl(posterFrontUrl);
@@ -256,5 +271,104 @@ public class PerformanceServiceImpl implements PerformanceService {
                 : -1;
 
         return new PerformanceSetlistResponse(currentSongId, setList);
+    }
+
+    // BandSession 생성 헬퍼 메서드
+    private void createBandSessions(PerformanceSong performanceSong, MembersDto membersDto) {
+        List<BandSession> bandSessions = new ArrayList<>();
+
+        // Vocal
+        if (membersDto.vocal() != null) {
+            for (String personName : membersDto.vocal()) {
+                Person person = getOrCreatePerson(personName);
+                bandSessions.add(BandSession.builder()
+                        .sessionType(SessionType.VOCAL)
+                        .performanceSong(performanceSong)
+                        .band(null) // Band 정보는 현재 없음
+                        .person(person)
+                        .build());
+            }
+        }
+
+        // Guitar1
+        if (membersDto.guitar1() != null) {
+            for (String personName : membersDto.guitar1()) {
+                Person person = getOrCreatePerson(personName);
+                bandSessions.add(BandSession.builder()
+                        .sessionType(SessionType.FIRSTGUITAR)
+                        .performanceSong(performanceSong)
+                        .band(null)
+                        .person(person)
+                        .build());
+            }
+        }
+
+        // Guitar2
+        if (membersDto.guitar2() != null) {
+            for (String personName : membersDto.guitar2()) {
+                Person person = getOrCreatePerson(personName);
+                bandSessions.add(BandSession.builder()
+                        .sessionType(SessionType.SECONDGUITAR)
+                        .performanceSong(performanceSong)
+                        .band(null)
+                        .person(person)
+                        .build());
+            }
+        }
+
+        // Bass
+        if (membersDto.bass() != null) {
+            for (String personName : membersDto.bass()) {
+                Person person = getOrCreatePerson(personName);
+                bandSessions.add(BandSession.builder()
+                        .sessionType(SessionType.BASE)
+                        .performanceSong(performanceSong)
+                        .band(null)
+                        .person(person)
+                        .build());
+            }
+        }
+
+        // Drum
+        if (membersDto.drum() != null) {
+            for (String personName : membersDto.drum()) {
+                Person person = getOrCreatePerson(personName);
+                bandSessions.add(BandSession.builder()
+                        .sessionType(SessionType.DRUM)
+                        .performanceSong(performanceSong)
+                        .band(null)
+                        .person(person)
+                        .build());
+            }
+        }
+
+        // Keyboard
+        if (membersDto.keyboard() != null) {
+            for (String personName : membersDto.keyboard()) {
+                Person person = getOrCreatePerson(personName);
+                bandSessions.add(BandSession.builder()
+                        .sessionType(SessionType.PIANO)
+                        .performanceSong(performanceSong)
+                        .band(null)
+                        .person(person)
+                        .build());
+            }
+        }
+
+        // 모든 BandSession 저장
+        if (!bandSessions.isEmpty()) {
+            bandSessionRepository.saveAll(bandSessions);
+        }
+    }
+
+    // Person 조회 또는 생성
+    private Person getOrCreatePerson(String name) {
+        return personRepository.findByName(name)
+                .orElseGet(() -> {
+                    Person newPerson = Person.builder()
+                            .name(name)
+                            .build();
+                    return personRepository.save(newPerson);
+                });
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
@@ -43,6 +43,16 @@ public record PerformanceCreateRequestDto(
 
         String openchatUrl,
 
+        String bankName,
+
+        String bankAccount,
+
+        String accountHolder,
+
+        String kakaopayUrl,
+
+        String naverpayUrl,
+
         // PerformanceMoreLink 리스트
         @Valid
         List<MoreLinkCreateDto> moreLinks,
@@ -71,7 +81,19 @@ public record PerformanceCreateRequestDto(
 
             @Valid
             @NotNull(message = "곡 정보는 필수 입력 항목입니다.")
-            SongCreateDto song
+            SongCreateDto song,
+
+            MembersDto members
+    ) {}
+
+    // 곡별 멤버 정보 DTO
+    public record MembersDto(
+            List<String> vocal,
+            List<String> guitar1,
+            List<String> guitar2,
+            List<String> bass,
+            List<String> drum,
+            List<String> keyboard
     ) {}
 
     // 곡 정보 DTO


### PR DESCRIPTION
## 연관 이슈
- close #72

## 작업 내용
- 사전 예매 관련 정보 조회 API 필드 추가 및 이름 변경
  - API 이름: `공연 문의 링크 조회` → `사전 예매 관련 정보 조회`
  - 추가 필드: `bankName`, `bankAccount`, `accountHolder`, `kakaopayUrl`, `naverpayUrl`
- 공연 생성 API에 결제 정보 필드 추가
  - Performance 엔티티에 결제/계좌 정보 필드 추가
  - PerformanceCreateRequestDto에 동일 필드 추가
- 공연 생성 API에 셋리스트 멤버 정보 기능 추가
  - PerformanceSongCreateDto에 `members` 필드 추가 (vocal, guitar1, guitar2, bass, drum, keyboard)
  - Person 엔티티 자동 생성 또는 조회 기능 추가
- 파일 업로드 크기 제한 증가
  - max-file-size: 50MB
  - max-request-size: 100MB

## 논의하고 싶은 내용
- `members` 필드를 optional로 처리한 것이 적절한지
- Person 엔티티를 이름만으로 조회/생성하는 방식의 동명이인 처리 방안
- 파일 업로드 크기 제한(50MB/100MB)이 적절한지

## 공유하고 싶은 내용
- 계좌 번호 복사 기능 구현을 위해 계좌 정보를 나눠서 따로 보내드렸습니다. 참고 부탁드려요. @a-neey 
<img width="117" height="62" alt="image" src="https://github.com/user-attachments/assets/05f81506-9f33-4a34-9512-e74a985d5cad" />

- Spring Boot multipart 파일 업로드 시 크기 제한은 `spring.servlet.multipart` 설정으로 조정 가능

## 기타
- 없음