### PR TITLE
ci(cd): 브랜치 분기 제거 및 SHA 기반 이미지 배포 적용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,16 +30,9 @@ jobs:
           script: |
             set -e
 
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
-            if [ "$BRANCH" = "main" ]; then
-              NAME="deulbull-prod"
-              PROFILE="prod"
-              DDL_AUTO="none"
-            else
-              NAME="deulbull-dev"
-              PROFILE="dev"
-              DDL_AUTO="update"
-            fi
+            NAME="deulbull-prod"
+            PROFILE="prod"
+            DDL_AUTO="none"
 
             cd /home/${{ secrets.SERVER_USER }}
 
@@ -57,8 +50,8 @@ jobs:
               echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             fi
 
-            echo "[1/4] Pull latest image..."
-            docker pull ${{ env.IMAGE }}:latest
+            echo "[1/4] Pull new image..."
+            docker pull ${{ env.IMAGE }}:${{ github.sha }}
 
             echo "[2/4] Restart Spring app..."
             docker compose rm -f ${NAME} || true


### PR DESCRIPTION
## 연관 이슈
- close #74 

## 작업 내용
- CD 브랜치 분기(main/develop) 로직 제거
- prod 고정 배포로 단순화
- latest 태그 대신 ${{ github.sha }} 기반 이미지 배포 적용
