### PR TITLE
settings: local, prod 환경 분리 및 .env 기반 설정 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,3 @@ replay_pid*
 .env.*
 application-secret.yml
 application-dev.yml
-application-prod.yml

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ replay_pid*
 .env.*
 application-secret.yml
 application-dev.yml
+application-local.yml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,31 @@
+# 배포용
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:none}
+    show-sql: ${SPRING_JPA_SHOW_SQL:false}
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 100MB
+
+jwt:
+  secret: ${JWT_SECRET}
+  expiration: ${JWT_EXPIRATION}
+
+sms:
+  api:
+    key: ${SMS_API_KEY}
+    secret: ${SMS_API_SECRET}
+  from: ${SMS_FROM}
+
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    region:
+      static: ${AWS_REGION_STATIC}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,17 +1,39 @@
-# 배포용
 spring:
+  config:
+    activate:
+      on-profile: prod
+
+  application:
+    name: deulbull-performance-api
+
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
+
   jpa:
+    show-sql: ${SPRING_JPA_SHOW_SQL:false}
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:none}
-    show-sql: ${SPRING_JPA_SHOW_SQL:false}
+
   servlet:
     multipart:
-      max-file-size: 50MB
-      max-request-size: 100MB
+      max-file-size: ${SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE:50MB}
+      max-request-size: ${SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE:100MB}
+
+server:
+  servlet:
+    context-path: /api
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  metrics:
+    export:
+      prometheus:
+        enabled: true
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,25 +1,19 @@
-# 공통
 spring:
   application:
     name: deulbull-performance-api
   profiles:
-    active: dev  # 기본은 개발환경 (서버에서는 prod로 덮어씀)
-  config:
-    import: optional:application-secret.yml
+    active: local
 
 server:
   servlet:
     context-path: /api
 
-# Actuator & Prometheus
 management:
   endpoints:
     web:
       exposure:
         include: health,info,prometheus,metrics
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
-    tags:
-      application: ${spring.application.name}


### PR DESCRIPTION
## 연관 이슈
- close #76 

## 작업 내용
기존 application-secret.yml 기반 키 관리를 .env 기반 관리로 변경
local, prod로 구분하도록 수정 (기존: dev, prod)

## 논의하고 싶은 내용
- 추후 dev 환경을 별도로 둘지, local / prod 2단계로 유지할지

## 공유하고 싶은 내용
- Spring Boot에서 운영 환경 설정 시 .env + GitHub Secrets + profile 분리 방식이 가장 깔끔하고 안전했음
- 확장성 측면에서도 infra 분리 및 Docker 배포에 유리한 구조라고 생각

## 기타
- 이후 RDS, S3, SMS 등 실제 운영 키는 모두 GitHub Secrets를 통해서만 관리 예정