### PR TITLE
feat: Prometheus metrics endpoint 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 	// AWS
 	implementation platform("software.amazon.awssdk:bom:2.25.70")
 	implementation "software.amazon.awssdk:s3"
+
+	// Prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,17 @@ spring:
     name: deulbull-performance-api
   profiles:
     active: local
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 server:
   servlet:
     context-path: /api
+  tomcat:
+    max-swallow-size: 50MB
+    max-http-form-post-size: 50MB
 
 management:
   endpoints:


### PR DESCRIPTION
## 연관 이슈

* close #76

## 작업 내용

* Prometheus에서 스프링 Actuator 메트릭을 끌어갈 수 있도록 Prometheus metrics endpoint 추가
* Spring Boot 3 / Tomcat 10 환경에서 발생하던 파일 업로드 제한(1MB) 문제 해결

  * Spring multipart 설정뿐만 아니라 Tomcat 기본 업로드 제한(max-swallow-size, max-http-form-post-size)도 조정
  * 이미지·포스터 등 대용량 파일 업로드 시 FileSizeLimitExceededException 발생 문제 해결

## 논의하고 싶은 내용

* 추가적으로 필요한 메트릭 태그나 수집 항목이 있는지
* 업로드 사이즈를 팀 기준에 맞춰 더 줄일지/늘릴지 여부

## 공유하고 싶은 내용

* Spring Boot 3.x에서는 multipart 업로드 제한이 Spring 설정 하나로 끝나지 않고 Tomcat 레벨 설정도 필요함
* Prometheus metrics는 `/actuator/prometheus` 로 고정되어 있어 별도 설정 없이도 수집 가능하지만 Docker Compose와 Nginx 리버스 프록시 환경에서는 경로 충돌 여부 확인이 필수임

## 기타

* 메트릭 수집과 파일 업로드 설정이 안정화되어 운영 환경에서의 장애 가능성이 줄어듦