### PR TITLE
fix: CD 배포 시 컨테이너 재시작 로직 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,9 +54,10 @@ jobs:
             docker pull ${{ env.IMAGE }}:${{ github.sha }}
 
             echo "[2/4] Restart Spring app..."
-            docker compose rm -f ${NAME} || true
-            docker compose up -d --no-deps ${NAME}
-
+            docker compose stop ${NAME}
+            docker compose rm -f ${NAME}
+            docker compose up -d ${NAME}
+            
             echo "[3/4] Check status..."
             docker compose ps
 


### PR DESCRIPTION
## 연관 이슈
- close #81 

## 작업 내용
배포 시 새 이미지가 pull되지만, 실제 컨테이너는 재시작되지 않아 변경사항이 반영되지 않는 문제 해결
1. `docker compose stop` 추가 → 컨테이너 먼저 중지
2. `docker compose rm -f` → 중지된 컨테이너 삭제
3. `docker compose up -d` → 새 이미지로 컨테이너 재생성
