### PR TITLE
fix(admin): 비밀번호 중복 검증 로직 추가

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminDuplicatePasswordException.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminDuplicatePasswordException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.admin.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class AdminDuplicatePasswordException extends BaseException {
+    public AdminDuplicatePasswordException() {
+        super(AdminErrorCode.ADMIN_409_DUPLICATE_PASSWORD);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/admin/exception/AdminErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/exception/AdminErrorCode.java
@@ -3,6 +3,7 @@ package com.deulbull.performance.domain.admin.exception;
 import com.deulbull.performance.global.response.code.BaseResponseCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import static com.deulbull.performance.global.constant.StaticValue.CONFLICT;
 import static com.deulbull.performance.global.constant.StaticValue.NOT_FOUND;
 import static com.deulbull.performance.global.constant.StaticValue.UNAUTHORIZED;
 
@@ -11,7 +12,8 @@ import static com.deulbull.performance.global.constant.StaticValue.UNAUTHORIZED;
 @RequiredArgsConstructor
 public enum AdminErrorCode implements BaseResponseCode {
     ADMIN_401_INVALID_PASSWORD("ADMIN_401_INVALID_PASSWORD", UNAUTHORIZED, "해당 비밀번호로 등록된 관리자가 존재하지 않습니다."),
-    ADMIN_404_NOT_FOUND("ADMIN_404_NOT_FOUND", NOT_FOUND, "해당 ID의 관리자가 존재하지 않습니다.");
+    ADMIN_404_NOT_FOUND("ADMIN_404_NOT_FOUND", NOT_FOUND, "해당 ID의 관리자가 존재하지 않습니다."),
+    ADMIN_409_DUPLICATE_PASSWORD("ADMIN_409_DUPLICATE_PASSWORD", CONFLICT, "이미 사용 중인 비밀번호입니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
@@ -2,6 +2,7 @@ package com.deulbull.performance.domain.admin.service;
 
 import com.deulbull.performance.domain.admin.entity.Admin;
 import com.deulbull.performance.domain.admin.entity.enums.AdminRole;
+import com.deulbull.performance.domain.admin.exception.AdminDuplicatePasswordException;
 import com.deulbull.performance.domain.admin.exception.AdminInvalidPasswordException;
 import com.deulbull.performance.domain.admin.exception.AdminNotFoundException;
 import com.deulbull.performance.domain.admin.repository.AdminRepository;
@@ -85,10 +86,19 @@ public class AdminServiceImpl implements AdminService {
         Band band = bandRepository.findById(bandId)
                 .orElseThrow(BandNotFoundException::new);
 
-        // 3. 비밀번호 암호화
+        // 3. 비밀번호 중복 검사
+        boolean isDuplicatePassword = adminRepository.findAll()
+                .stream()
+                .anyMatch(admin -> passwordEncoder.matches(password, admin.getPassword()));
+
+        if (isDuplicatePassword) {
+            throw new AdminDuplicatePasswordException();
+        }
+
+        // 4. 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(password);
 
-        // 4. Admin 생성
+        // 5. Admin 생성
         Admin admin = Admin.builder()
                 .role(role)
                 .password(encodedPassword)
@@ -96,13 +106,13 @@ public class AdminServiceImpl implements AdminService {
                 .band(band)
                 .build();
 
-        // 5. DB에 저장
+        // 6. DB에 저장
         Admin savedAdmin = adminRepository.save(admin);
 
-        // 6. JWT 토큰 생성
+        // 7. JWT 토큰 생성
         String token = jwtTokenProvider.createToken(savedAdmin);
 
-        // 7. 반환
+        // 8. 반환
         return new AdminSignupResponseDto(token);
     }
 


### PR DESCRIPTION
## 연관 이슈
- close #54 

## 작업 내용
- 관리자 계정은 고유한 비밀번호를 기준으로 식별되기 때문에 비밀번호 중복 여부를 사전에 검증하는 로직이 필수적
- 관리자 회원가입 시 비밀번호 중복 검사 로직 추가

> 409 비밀번호 중복 예외처리 추가
<img width="407" height="245" alt="image" src="https://github.com/user-attachments/assets/7adc95e9-2adf-415d-aa92-4f56b27a4a93" />
