### PR TITLE
fix: 도커 컨테이너를 무조건 새로 생성하도록 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,12 +51,11 @@ jobs:
             fi
 
             echo "[1/4] Pull new image..."
-            docker pull ${{ env.IMAGE }}:${{ github.sha }}
+            docker pull ${{ env.IMAGE }}:latest
 
             echo "[2/4] Restart Spring app..."
-            docker compose stop ${NAME}
-            docker compose rm -f ${NAME}
-            docker compose up -d ${NAME}
+            docker compose pull ${NAME}
+            docker compose up -d --force-recreate --no-deps ${NAME}
             
             echo "[3/4] Check status..."
             docker compose ps


### PR DESCRIPTION
## 작업 내용
- CD 워크플로우의 Docker 컨테이너 재시작 로직 수정
- 기존: `docker compose stop` → `rm` → `up` 방식
- 변경: `docker compose pull` → `up --force-recreate --no-deps` 방식
- 새 이미지가 빌드되어도 컨테이너가 업데이트되지 않던 문제 해결


## 공유하고 싶은 내용
- `--force-recreate` 옵션을 사용하면 이미지 변경 여부와 관계없이 컨테이너를 새로 생성
- `--no-deps` 옵션으로 prometheus, grafana 등 다른 서비스는 영향받지 않도록 설정
- 기존 방식은 docker compose가 이미지 변경을 감지하지 못하는 경우가 있었음
