### PR TITLE
fix: Performance 엔티티 및 세션타입 약어 적용, 셋리스트 URL 반영

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/band/entity/enums/SessionType.java
+++ b/src/main/java/com/deulbull/performance/domain/band/entity/enums/SessionType.java
@@ -1,13 +1,13 @@
 package com.deulbull.performance.domain.band.entity.enums;
 
 public enum SessionType {
-    FIRSTGUITAR,
-    SECONDGUITAR,
-    THIRDGUITAR,
-    DRUM,
-    VOCAL,
-    CHORUS,
-    BASE,
-    PIANO,
-    ETC
+    G1,  // 1st Guitar
+    G2,  // 2nd Guitar
+    G3,  // 3rd Guitar
+    D,   // Drum
+    V,   // Vocal
+    CH,  // Chorus
+    B,   // Bass
+    K,   // Keyboard / Piano
+    ETC  // 기타
 }

--- a/src/main/java/com/deulbull/performance/domain/band/exception/BandErrorCode.java
+++ b/src/main/java/com/deulbull/performance/domain/band/exception/BandErrorCode.java
@@ -9,7 +9,8 @@ import static com.deulbull.performance.global.constant.StaticValue.BAD_REQUEST;
 @AllArgsConstructor
 @Getter
 public enum BandErrorCode implements BaseResponseCode {
-    BAND_404_NOT_FOUND("BAND_404_NOT_FOUND", BAD_REQUEST, "해당 ID의 밴드를 찾을 수 없습니다.");
+    BAND_404_NOT_FOUND("BAND_404_NOT_FOUND", BAD_REQUEST, "해당 ID의 밴드를 찾을 수 없습니다."),
+    PERSON_404_NOT_FOUND("PERSON_404_NOT_FOUND", BAD_REQUEST, "해당 ID의 사람을 찾을 수 없습니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/deulbull/performance/domain/band/exception/PersonNotFoundException.java
+++ b/src/main/java/com/deulbull/performance/domain/band/exception/PersonNotFoundException.java
@@ -1,0 +1,9 @@
+package com.deulbull.performance.domain.band.exception;
+
+import com.deulbull.performance.global.exception.BaseException;
+
+public class PersonNotFoundException extends BaseException {
+    public PersonNotFoundException() {
+        super(BandErrorCode.PERSON_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
@@ -36,6 +36,7 @@ public class Performance extends BaseEntity {
     private String accountHolder; // 예금주
     private String kakaopayUrl; // 카카오페이 결제 URL
     private String naverpayUrl; // 네이버페이 결제 URL
+    private String setlistUrl; // 셋리스트 이미지 또는 파일 URL
 
     @ManyToOne
     @JoinColumn(name = "current_song_id")

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -75,6 +75,7 @@ public class PerformanceServiceImpl implements PerformanceService {
                 .accountHolder(requestDto.accountHolder())
                 .kakaopayUrl(requestDto.kakaopayUrl())
                 .naverpayUrl(requestDto.naverpayUrl())
+                .setlistUrl(requestDto.setlistUrl())
                 .currentSong(null) // 초기에는 현재 곡 없음
                 .build();
 
@@ -270,7 +271,7 @@ public class PerformanceServiceImpl implements PerformanceService {
                 ? performance.getCurrentSong().getOrderInPerformance()
                 : -1;
 
-        return new PerformanceSetlistResponse(currentSongId, setList);
+        return new PerformanceSetlistResponse(currentSongId, performance.getSetlistUrl(), setList);
     }
 
     // BandSession 생성 헬퍼 메서드

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -283,7 +283,7 @@ public class PerformanceServiceImpl implements PerformanceService {
             for (String personName : membersDto.vocal()) {
                 Person person = getOrCreatePerson(personName);
                 bandSessions.add(BandSession.builder()
-                        .sessionType(SessionType.VOCAL)
+                        .sessionType(SessionType.V)
                         .performanceSong(performanceSong)
                         .band(null) // Band 정보는 현재 없음
                         .person(person)
@@ -296,7 +296,7 @@ public class PerformanceServiceImpl implements PerformanceService {
             for (String personName : membersDto.guitar1()) {
                 Person person = getOrCreatePerson(personName);
                 bandSessions.add(BandSession.builder()
-                        .sessionType(SessionType.FIRSTGUITAR)
+                        .sessionType(SessionType.G1)
                         .performanceSong(performanceSong)
                         .band(null)
                         .person(person)
@@ -309,7 +309,7 @@ public class PerformanceServiceImpl implements PerformanceService {
             for (String personName : membersDto.guitar2()) {
                 Person person = getOrCreatePerson(personName);
                 bandSessions.add(BandSession.builder()
-                        .sessionType(SessionType.SECONDGUITAR)
+                        .sessionType(SessionType.G2)
                         .performanceSong(performanceSong)
                         .band(null)
                         .person(person)
@@ -322,7 +322,7 @@ public class PerformanceServiceImpl implements PerformanceService {
             for (String personName : membersDto.bass()) {
                 Person person = getOrCreatePerson(personName);
                 bandSessions.add(BandSession.builder()
-                        .sessionType(SessionType.BASE)
+                        .sessionType(SessionType.B)
                         .performanceSong(performanceSong)
                         .band(null)
                         .person(person)
@@ -335,7 +335,7 @@ public class PerformanceServiceImpl implements PerformanceService {
             for (String personName : membersDto.drum()) {
                 Person person = getOrCreatePerson(personName);
                 bandSessions.add(BandSession.builder()
-                        .sessionType(SessionType.DRUM)
+                        .sessionType(SessionType.D)
                         .performanceSong(performanceSong)
                         .band(null)
                         .person(person)
@@ -348,7 +348,7 @@ public class PerformanceServiceImpl implements PerformanceService {
             for (String personName : membersDto.keyboard()) {
                 Person person = getOrCreatePerson(personName);
                 bandSessions.add(BandSession.builder()
-                        .sessionType(SessionType.PIANO)
+                        .sessionType(SessionType.K)
                         .performanceSong(performanceSong)
                         .band(null)
                         .person(person)

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateRequestDto.java
@@ -53,6 +53,8 @@ public record PerformanceCreateRequestDto(
 
         String naverpayUrl,
 
+        String setlistUrl,
+
         // PerformanceMoreLink 리스트
         @Valid
         List<MoreLinkCreateDto> moreLinks,

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
@@ -3,6 +3,7 @@ import java.util.List;
 
 public record PerformanceSetlistResponse(
         int nowPlayingOrder,
+        String setListUrl,
         List<PerformanceSetListDetail> setlist
 ) {
     public record PerformanceSetListDetail(

--- a/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performanceSongs/repository/PerformanceSongsRepository.java
@@ -48,4 +48,7 @@ public interface PerformanceSongsRepository extends JpaRepository<PerformanceSon
         where ps.id = :performanceSongId
     """)
     Optional<CurrentSongProjection> findProjectionById(@Param("performanceSongId") Long performanceSongId);
+
+    // performanceId와 songId로 PerformanceSong 찾기
+    Optional<PerformanceSong> findByPerformanceIdAndSongId(Long performanceId, Long songId);
 }

--- a/src/main/java/com/deulbull/performance/domain/song/service/SongService.java
+++ b/src/main/java/com/deulbull/performance/domain/song/service/SongService.java
@@ -2,10 +2,13 @@ package com.deulbull.performance.domain.song.service;
 
 import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
 import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
+import com.deulbull.performance.domain.song.web.dto.SongPersonConnectRequestDto;
+import com.deulbull.performance.domain.song.web.dto.SongPersonConnectResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface SongService {
     SongCreateResponseDto createSongs(SongCreateRequestDto requestDto, List<MultipartFile> albumImages);
+    SongPersonConnectResponseDto connectSongToPerson(SongPersonConnectRequestDto requestDto);
 }

--- a/src/main/java/com/deulbull/performance/domain/song/service/SongService.java
+++ b/src/main/java/com/deulbull/performance/domain/song/service/SongService.java
@@ -1,0 +1,11 @@
+package com.deulbull.performance.domain.song.service;
+
+import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
+import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface SongService {
+    SongCreateResponseDto createSongs(SongCreateRequestDto requestDto, List<MultipartFile> albumImages);
+}

--- a/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
@@ -2,13 +2,16 @@ package com.deulbull.performance.domain.song.service;
 
 import com.deulbull.performance.domain.band.entity.BandSession;
 import com.deulbull.performance.domain.band.entity.Person;
+import com.deulbull.performance.domain.band.exception.PersonNotFoundException;
 import com.deulbull.performance.domain.band.repository.BandSessionRepository;
 import com.deulbull.performance.domain.band.repository.PersonRepository;
 import com.deulbull.performance.domain.performance.entity.Performance;
+import com.deulbull.performance.domain.performance.exception.PerformanceNotFoundException;
 import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
 import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
 import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
 import com.deulbull.performance.domain.song.entity.Song;
+import com.deulbull.performance.domain.song.exception.SongNotFoundException;
 import com.deulbull.performance.domain.song.repository.SongRepository;
 import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
 import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
@@ -94,13 +97,13 @@ public class SongServiceImpl implements SongService {
     public SongPersonConnectResponseDto connectSongToPerson(SongPersonConnectRequestDto requestDto) {
         // 1. Song, Performance, Person 엔티티 조회
         Song song = songRepository.findById(requestDto.songId())
-                .orElseThrow(() -> new IllegalArgumentException("곡을 찾을 수 없습니다: " + requestDto.songId()));
+                .orElseThrow(SongNotFoundException::new);
 
         Performance performance = performanceRepository.findById(requestDto.performanceId())
-                .orElseThrow(() -> new IllegalArgumentException("공연을 찾을 수 없습니다: " + requestDto.performanceId()));
+                .orElseThrow(PerformanceNotFoundException::new);
 
         Person person = personRepository.findById(requestDto.personId())
-                .orElseThrow(() -> new IllegalArgumentException("사람을 찾을 수 없습니다: " + requestDto.personId()));
+                .orElseThrow(PersonNotFoundException::new);
 
         // 2. PerformanceSong을 찾거나 생성
         PerformanceSong performanceSong = performanceSongsRepository

--- a/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
@@ -1,0 +1,88 @@
+package com.deulbull.performance.domain.song.service;
+
+import com.deulbull.performance.domain.song.entity.Song;
+import com.deulbull.performance.domain.song.repository.SongRepository;
+import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
+import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
+import com.deulbull.performance.global.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SongServiceImpl implements SongService {
+
+    private final SongRepository songRepository;
+    private final S3Uploader s3Uploader;
+
+    @Override
+    @Transactional
+    public SongCreateResponseDto createSongs(SongCreateRequestDto requestDto, List<MultipartFile> albumImages) {
+        List<SongCreateResponseDto.SongDetail> createdSongs = new ArrayList<>();
+        List<SongCreateRequestDto.SongInfo> songInfos = requestDto.songs();
+
+        for (int i = 0; i < songInfos.size(); i++) {
+            SongCreateRequestDto.SongInfo songInfo = songInfos.get(i);
+
+            // 1. Song 엔티티 생성
+            Song song = Song.builder()
+                    .artist(songInfo.artist())
+                    .title(songInfo.title())
+                    .album(songInfo.album())
+                    .releaseDate(parseDate(songInfo.releaseDate()))
+                    .genre(songInfo.genre())
+                    .youtubeUrl(songInfo.youtubeUrl())
+                    .lyrics(songInfo.lyrics())
+                    .albumImgUrl(null) // 초기값 null
+                    .build();
+
+            songRepository.save(song);
+
+            // 2. 앨범 이미지가 있으면 S3에 업로드
+            String albumImgUrl = null;
+            if (albumImages != null && i < albumImages.size()) {
+                MultipartFile albumImage = albumImages.get(i);
+                if (albumImage != null && !albumImage.isEmpty()) {
+                    albumImgUrl = s3Uploader.upload(
+                            albumImage,
+                            "song/" + song.getId() + "/album-img"
+                    );
+                    song.setAlbumImgUrl(albumImgUrl);
+                }
+            }
+
+            // 3. 응답 DTO 생성
+            createdSongs.add(new SongCreateResponseDto.SongDetail(
+                    song.getId(),
+                    song.getArtist(),
+                    song.getTitle(),
+                    song.getAlbum(),
+                    song.getReleaseDate() != null ? song.getReleaseDate().toString() : null,
+                    song.getGenre(),
+                    song.getYoutubeUrl(),
+                    song.getAlbumImgUrl(),
+                    song.getLyrics()
+            ));
+        }
+
+        return new SongCreateResponseDto(createdSongs.size(), createdSongs);
+    }
+
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(dateStr, DateTimeFormatter.ISO_DATE);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
@@ -1,9 +1,19 @@
 package com.deulbull.performance.domain.song.service;
 
+import com.deulbull.performance.domain.band.entity.BandSession;
+import com.deulbull.performance.domain.band.entity.Person;
+import com.deulbull.performance.domain.band.repository.BandSessionRepository;
+import com.deulbull.performance.domain.band.repository.PersonRepository;
+import com.deulbull.performance.domain.performance.entity.Performance;
+import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
+import com.deulbull.performance.domain.performanceSongs.entity.PerformanceSong;
+import com.deulbull.performance.domain.performanceSongs.repository.PerformanceSongsRepository;
 import com.deulbull.performance.domain.song.entity.Song;
 import com.deulbull.performance.domain.song.repository.SongRepository;
 import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
 import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
+import com.deulbull.performance.domain.song.web.dto.SongPersonConnectRequestDto;
+import com.deulbull.performance.domain.song.web.dto.SongPersonConnectResponseDto;
 import com.deulbull.performance.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +31,10 @@ public class SongServiceImpl implements SongService {
 
     private final SongRepository songRepository;
     private final S3Uploader s3Uploader;
+    private final PersonRepository personRepository;
+    private final PerformanceRepository performanceRepository;
+    private final PerformanceSongsRepository performanceSongsRepository;
+    private final BandSessionRepository bandSessionRepository;
 
     @Override
     @Transactional
@@ -73,6 +87,58 @@ public class SongServiceImpl implements SongService {
         }
 
         return new SongCreateResponseDto(createdSongs.size(), createdSongs);
+    }
+
+    @Override
+    @Transactional
+    public SongPersonConnectResponseDto connectSongToPerson(SongPersonConnectRequestDto requestDto) {
+        // 1. Song, Performance, Person 엔티티 조회
+        Song song = songRepository.findById(requestDto.songId())
+                .orElseThrow(() -> new IllegalArgumentException("곡을 찾을 수 없습니다: " + requestDto.songId()));
+
+        Performance performance = performanceRepository.findById(requestDto.performanceId())
+                .orElseThrow(() -> new IllegalArgumentException("공연을 찾을 수 없습니다: " + requestDto.performanceId()));
+
+        Person person = personRepository.findById(requestDto.personId())
+                .orElseThrow(() -> new IllegalArgumentException("사람을 찾을 수 없습니다: " + requestDto.personId()));
+
+        // 2. PerformanceSong을 찾거나 생성
+        PerformanceSong performanceSong = performanceSongsRepository
+                .findByPerformanceIdAndSongId(requestDto.performanceId(), requestDto.songId())
+                .orElseGet(() -> {
+                    // 새로 생성
+                    PerformanceSong newPerformanceSong = PerformanceSong.builder()
+                            .performance(performance)
+                            .song(song)
+                            .orderInPerformance(null) // 나중에 순서 설정 가능
+                            .likes(0)
+                            .build();
+                    return performanceSongsRepository.save(newPerformanceSong);
+                });
+
+        // 3. BandSession 생성
+        BandSession bandSession = BandSession.builder()
+                .performanceSong(performanceSong)
+                .person(person)
+                .sessionType(requestDto.sessionType())
+                .band(null) // 일단 null
+                .build();
+
+        bandSessionRepository.save(bandSession);
+
+        // 4. 응답 DTO 생성
+        return SongPersonConnectResponseDto.builder()
+                .bandSessionId(bandSession.getId())
+                .performanceSongId(performanceSong.getId())
+                .songId(song.getId())
+                .songTitle(song.getTitle())
+                .songArtist(song.getArtist())
+                .personId(person.getId())
+                .personName(person.getName())
+                .sessionType(requestDto.sessionType())
+                .performanceId(performance.getId())
+                .performanceTitle(performance.getTitle())
+                .build();
     }
 
     private LocalDate parseDate(String dateStr) {

--- a/src/main/java/com/deulbull/performance/domain/song/web/controller/SongController.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/controller/SongController.java
@@ -1,0 +1,34 @@
+package com.deulbull.performance.domain.song.web.controller;
+
+import com.deulbull.performance.domain.song.service.SongService;
+import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
+import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
+import com.deulbull.performance.global.response.SuccessResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/songs")
+@RequiredArgsConstructor
+public class SongController {
+
+    private final SongService songService;
+    private final ObjectMapper objectMapper;
+
+    @PostMapping
+    public SuccessResponse<SongCreateResponseDto> createSongs(
+            @RequestPart("data") String requestData,
+            @RequestPart(value = "albumImages", required = false) List<MultipartFile> albumImages
+    ) {
+        try {
+            SongCreateRequestDto requestDto = objectMapper.readValue(requestData, SongCreateRequestDto.class);
+            return SuccessResponse.ok(songService.createSongs(requestDto, albumImages));
+        } catch (Exception e) {
+            throw new RuntimeException("Invalid request data: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/song/web/controller/SongController.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/controller/SongController.java
@@ -3,8 +3,11 @@ package com.deulbull.performance.domain.song.web.controller;
 import com.deulbull.performance.domain.song.service.SongService;
 import com.deulbull.performance.domain.song.web.dto.SongCreateRequestDto;
 import com.deulbull.performance.domain.song.web.dto.SongCreateResponseDto;
+import com.deulbull.performance.domain.song.web.dto.SongPersonConnectRequestDto;
+import com.deulbull.performance.domain.song.web.dto.SongPersonConnectResponseDto;
 import com.deulbull.performance.global.response.SuccessResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,5 +33,12 @@ public class SongController {
         } catch (Exception e) {
             throw new RuntimeException("Invalid request data: " + e.getMessage(), e);
         }
+    }
+
+    @PostMapping("/connect-person")
+    public SuccessResponse<SongPersonConnectResponseDto> connectSongToPerson(
+            @Valid @RequestBody SongPersonConnectRequestDto requestDto
+    ) {
+        return SuccessResponse.ok(songService.connectSongToPerson(requestDto));
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/song/web/dto/SongCreateRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/dto/SongCreateRequestDto.java
@@ -1,0 +1,28 @@
+package com.deulbull.performance.domain.song.web.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record SongCreateRequestDto(
+        @NotNull(message = "곡 목록은 필수입니다.")
+        @Valid
+        List<SongInfo> songs
+) {
+    public record SongInfo(
+            @NotBlank(message = "아티스트는 필수입니다.")
+            String artist,
+
+            @NotBlank(message = "제목은 필수입니다.")
+            String title,
+
+            String album,
+            String releaseDate, // "YYYY-MM-DD" 형식
+            String genre,
+            String youtubeUrl,
+            String lyrics
+    ) {
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/song/web/dto/SongCreateResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/dto/SongCreateResponseDto.java
@@ -1,0 +1,21 @@
+package com.deulbull.performance.domain.song.web.dto;
+
+import java.util.List;
+
+public record SongCreateResponseDto(
+        int totalCreated,
+        List<SongDetail> songs
+) {
+    public record SongDetail(
+            Long songId,
+            String artist,
+            String title,
+            String album,
+            String releaseDate,
+            String genre,
+            String youtubeUrl,
+            String albumImgUrl,
+            String lyrics
+    ) {
+    }
+}

--- a/src/main/java/com/deulbull/performance/domain/song/web/dto/SongPersonConnectRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/dto/SongPersonConnectRequestDto.java
@@ -1,0 +1,19 @@
+package com.deulbull.performance.domain.song.web.dto;
+
+import com.deulbull.performance.domain.band.entity.enums.SessionType;
+import jakarta.validation.constraints.NotNull;
+
+public record SongPersonConnectRequestDto(
+        @NotNull(message = "곡 ID는 필수입니다.")
+        Long songId,
+
+        @NotNull(message = "공연 ID는 필수입니다.")
+        Long performanceId,
+
+        @NotNull(message = "사람 ID는 필수입니다.")
+        Long personId,
+
+        @NotNull(message = "세션 타입은 필수입니다.")
+        SessionType sessionType
+) {
+}

--- a/src/main/java/com/deulbull/performance/domain/song/web/dto/SongPersonConnectResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/dto/SongPersonConnectResponseDto.java
@@ -1,0 +1,19 @@
+package com.deulbull.performance.domain.song.web.dto;
+
+import com.deulbull.performance.domain.band.entity.enums.SessionType;
+import lombok.Builder;
+
+@Builder
+public record SongPersonConnectResponseDto(
+        Long bandSessionId,
+        Long performanceSongId,
+        Long songId,
+        String songTitle,
+        String songArtist,
+        Long personId,
+        String personName,
+        SessionType sessionType,
+        Long performanceId,
+        String performanceTitle
+) {
+}

--- a/src/test/java/com/deulbull/performance/domain/booking/web/controller/PerformanceSongsControllerTest.java
+++ b/src/test/java/com/deulbull/performance/domain/booking/web/controller/PerformanceSongsControllerTest.java
@@ -52,8 +52,8 @@ class PerformanceSongsControllerTest {
         );
 
         var team = List.of(
-                new PerformanceSongsDetailResponseDto.Team(SessionType.VOCAL, "강범준", "beom_jun"),
-                new PerformanceSongsDetailResponseDto.Team(SessionType.DRUM,  "김주호", "juho_kim")
+                new PerformanceSongsDetailResponseDto.Team(SessionType.V, "강범준", "beom_jun"),
+                new PerformanceSongsDetailResponseDto.Team(SessionType.D,  "김주호", "juho_kim")
         );
 
         var dto = new PerformanceSongsDetailResponseDto(track, team);
@@ -74,7 +74,7 @@ class PerformanceSongsControllerTest {
     void getTrackDetail_notFound() throws Exception {
         Long performanceSongId = 9999L;
 
-        // ✅ 커스텀 예외를 던지도록 스텁 (메서드명 정확!)
+        // 커스텀 예외를 던지도록 스텁 
         Mockito.when(performanceSongsService.getPerformanceSongsDetail(eq(performanceSongId)))
                 .thenThrow(new PerformanceSongsNotFoundException());
 


### PR DESCRIPTION
## 연관 이슈
- close #89

## 작업 내용
1. **Performance 엔티티에 `setlistUrl` 필드 추가**

   * 공연 셋리스트 이미지/파일 URL을 저장하기 위한 필드 추가
   * `PerformanceCreateRequestDto`, `PerformanceServiceImpl` 수정하여 생성 시 반영
   * `PerformanceSetlistResponse`에 `setlistUrl` 포함되도록 구조 확장

2. **SessionType 값 약어로 전면 변경**

   * 기존 FULL NAME(Enum: FIRSTGUITAR 등) → 약어(G1, G2, V, D, B, K, CH, ETC)
   * 서비스 전반에서 약어 기준으로 정리
   * Enum 변경에 따라 기존 DB ENUM 값도 ALTER 필요
     → 마이그레이션 스크립트 별도 진행 예정

3. **셋리스트 응답 구조 개선**

   * 기존: `nowPlayingOrder + setlist`
   * 변경: `nowPlayingOrder + setlistUrl + setlist`
   * 프론트에서 이미지 기반 셋리스트 활용 가능하도록 확장

4. **곡 추가 API 기능 추가 및 예외 처리 강화**

   * Song 생성 로직 추가
   * 세션 타입 변경으로 발생 가능한 예외에 대한 처리 보완


## 논의하고 싶은 내용
- SessionType 변경으로 인해 DB ENUM 타입도 신규 값(G1, G2…)으로 ALTER 필요합니다.
- 기존 데이터 마이그레이션은 별도 쿼리 스크립트로 처리 예정입니다.

## 공유하고 싶은 내용
- 셋리스트 기능 확장으로 프론트엔드에서도 setListUrl을 사용할 수 있게 됩니다.
