### PR TITLE
feat(song): 곡-사람 연결 API 추가 및 곡 생성 로직 개선

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/song/service/SongServiceImpl.java
@@ -48,26 +48,26 @@ public class SongServiceImpl implements SongService {
         for (int i = 0; i < songInfos.size(); i++) {
             SongCreateRequestDto.SongInfo songInfo = songInfos.get(i);
 
-            // 1. Song 엔티티 생성
-            Song song = Song.builder()
-                    .artist(songInfo.artist())
-                    .title(songInfo.title())
-                    .album(songInfo.album())
-                    .releaseDate(parseDate(songInfo.releaseDate()))
-                    .genre(songInfo.genre())
-                    .youtubeUrl(songInfo.youtubeUrl())
-                    .lyrics(songInfo.lyrics())
-                    .albumImgUrl(null) // 초기값 null
-                    .build();
+            // 1. 같은 title의 Song이 있는지 확인하고, 있으면 수정, 없으면 생성
+            Song song = songRepository.findByTitleAndArtist(songInfo.title(), songInfo.artist())
+                    .orElseGet(() -> Song.builder().build());
+
+            // 2. Song 정보 업데이트
+            song.setArtist(songInfo.artist());
+            song.setTitle(songInfo.title());
+            song.setAlbum(songInfo.album());
+            song.setReleaseDate(parseDate(songInfo.releaseDate()));
+            song.setGenre(songInfo.genre());
+            song.setYoutubeUrl(songInfo.youtubeUrl());
+            song.setLyrics(songInfo.lyrics());
 
             songRepository.save(song);
 
-            // 2. 앨범 이미지가 있으면 S3에 업로드
-            String albumImgUrl = null;
+            // 3. 앨범 이미지가 있으면 S3에 업로드
             if (albumImages != null && i < albumImages.size()) {
                 MultipartFile albumImage = albumImages.get(i);
                 if (albumImage != null && !albumImage.isEmpty()) {
-                    albumImgUrl = s3Uploader.upload(
+                    String albumImgUrl = s3Uploader.upload(
                             albumImage,
                             "song/" + song.getId() + "/album-img"
                     );
@@ -75,7 +75,7 @@ public class SongServiceImpl implements SongService {
                 }
             }
 
-            // 3. 응답 DTO 생성
+            // 4. 응답 DTO 생성
             createdSongs.add(new SongCreateResponseDto.SongDetail(
                     song.getId(),
                     song.getArtist(),
@@ -113,11 +113,17 @@ public class SongServiceImpl implements SongService {
                     PerformanceSong newPerformanceSong = PerformanceSong.builder()
                             .performance(performance)
                             .song(song)
-                            .orderInPerformance(null) // 나중에 순서 설정 가능
+                            .orderInPerformance(requestDto.orderInPerformance())
                             .likes(0)
                             .build();
                     return performanceSongsRepository.save(newPerformanceSong);
                 });
+
+        // orderInPerformance가 제공되었으면 업데이트
+        if (requestDto.orderInPerformance() != null) {
+            performanceSong.setOrderInPerformance(requestDto.orderInPerformance());
+            performanceSongsRepository.save(performanceSong);
+        }
 
         // 3. BandSession 생성
         BandSession bandSession = BandSession.builder()

--- a/src/main/java/com/deulbull/performance/domain/song/web/dto/SongPersonConnectRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/song/web/dto/SongPersonConnectRequestDto.java
@@ -14,6 +14,8 @@ public record SongPersonConnectRequestDto(
         Long personId,
 
         @NotNull(message = "세션 타입은 필수입니다.")
-        SessionType sessionType
+        SessionType sessionType,
+
+        Integer orderInPerformance
 ) {
 }


### PR DESCRIPTION
## 연관 이슈

* close #89

## 작업 내용

* **곡 생성 로직 개선**

  * 동일한 `title + artist` 조합이 존재하면 신규 생성 대신 기존 엔티티를 업데이트하는 방식으로 개선
  * 앨범 이미지가 있을 경우 S3 업로드 후 `albumImgUrl` 반영
* **곡-사람 연결 API 기능 확장**

  * 기존 `PerformanceSong`가 존재하면 업데이트, 없으면 신규 생성
  * `orderInPerformance` 필드 추가 및 전달 시 바로 반영
  * `SongPersonConnectRequestDto`에 `orderInPerformance` 필드 추가
* 전반적으로 생성·연결 과정의 중복 생성 방지 및 데이터 일관성 개선

## 논의하고 싶은 내용

* 기존 공연들에 대해 orderInPerformance 미적용 데이터 마이그레이션 필요 여부
* 향후 Song 중복 판정 기준(title/artist 외 확장 여부)