### PR TITLE
fix(#92): 예매 알림·캐싱·서버 환경 최종 수정 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
-	// webp
-//	implementation 'com.luciad.imageio-webp:imageio-webp:0.8.1'
-	implementation 'com.github.gotson:webp-imageio:0.2.2'
+	// image compress
+	implementation 'org.imgscalr:imgscalr-lib:4.2'
 
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ dependencies {
 	// Prometheus
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+	// webp
+//	implementation 'com.luciad.imageio-webp:imageio-webp:0.8.1'
+	implementation 'com.github.gotson:webp-imageio:0.2.2'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
@@ -16,6 +16,6 @@ public interface AdminMessageService {
     void sendBookingConfirmationMessage(String phoneNumber, String name, int headCount, int totalPrice, String openchatUrl);
 
     // 간단 문자 발송
-    void sendSimpleAdminMessage(String content);
+    void sendSimpleAdminMessage(String phoneNumber, String content);
 
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
@@ -14,4 +14,8 @@ public interface AdminMessageService {
 
     // 사전예매 확인 문자 발송
     void sendBookingConfirmationMessage(String phoneNumber, String name, int headCount, int totalPrice, String openchatUrl);
+
+    // 간단 문자 발송
+    void sendSimpleAdminMessage(String content);
+
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageService.java
@@ -11,4 +11,7 @@ public interface AdminMessageService {
 
     // 단체 문자 발송
     void sendBulkMessage(Long adminId, @Valid AdminMessageRequestDto adminMessageRequestDto);
+
+    // 사전예매 확인 문자 발송
+    void sendBookingConfirmationMessage(String phoneNumber, String name, int headCount, int totalPrice, String openchatUrl);
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -148,5 +148,25 @@ public class AdminMessageServiceImpl implements AdminMessageService {
         }
     }
 
+    // 간단 문자 발송
+    @Override
+    public void sendSimpleAdminMessage(String phoneNumber, String messageText) {
+        try {
+            DefaultMessageService smsService =
+                    NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+
+            Message message = new Message();
+            message.setFrom(sender);
+            message.setTo(phoneNumber);
+            message.setText(messageText);
+
+            smsService.sendOne(new SingleMessageSendingRequest(message));
+
+            System.out.println("[예매 수정/삭제 문자 발송 성공] to=" + phoneNumber);
+        } catch (Exception e) {
+            System.out.println("[예매 수정/삭제 문자 발송 실패] to=" + phoneNumber + ", error=" + e.getMessage());
+            // 문자 발송 실패해도 예매는 정상적으로 처리되도록 예외를 던지지 않음
+        }
+    }
 
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -7,21 +7,30 @@ import com.deulbull.performance.domain.admin.web.dto.AdminMessageRequestDto;
 import com.deulbull.performance.domain.admin.web.dto.AdminMessageTargetCountResponseDto;
 import com.deulbull.performance.domain.booking.entity.Booking;
 import com.deulbull.performance.domain.booking.repository.BookingRepository;
+import com.deulbull.performance.domain.booking.service.BookingServiceImpl;
 import com.deulbull.performance.domain.performance.entity.Performance;
+import com.deulbull.performance.global.discord.DiscordWebhookSender;
 import net.nurigo.sdk.message.model.Message;
 import lombok.RequiredArgsConstructor;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class AdminMessageServiceImpl implements AdminMessageService {
+    private static final Logger log = LoggerFactory.getLogger(BookingServiceImpl.class);
     private final AdminRepository adminRepository;
     private final BookingRepository bookingRepository;
+    private final DiscordWebhookSender discordWebhookSender;
 
     @Value("${sms.api.key}")
     private String apiKey;
@@ -72,12 +81,22 @@ public class AdminMessageServiceImpl implements AdminMessageService {
         int successCount = 0;
         int failCount = 0;
 
-        // 문자 발송
+        // 이미 문자 보낸 전화번호 저장
+        Set<String> sentPhones = new HashSet<>();
+
         for (Booking booking : bookings) {
+
+            String phone = booking.getPhoneNumber();
+
+            // 이미 문자 보낸 전화번호면 skip
+            if (sentPhones.contains(phone)) {
+                continue;
+            }
+
             try {
                 Message message = new Message();
                 message.setFrom(sender);
-                message.setTo(booking.getPhoneNumber());
+                message.setTo(phone);
                 message.setText(adminMessageRequestDto.getMessage());
 
                 if ("LMS".equalsIgnoreCase(adminMessageRequestDto.getType())) {
@@ -85,19 +104,25 @@ public class AdminMessageServiceImpl implements AdminMessageService {
                 }
 
                 smsService.sendOne(new SingleMessageSendingRequest(message));
-                successCount++;
-            } catch (Exception e) {
 
-                System.out.println("문자 발송 실패 (" + booking.getPerformance() + "): " + e.getMessage());
+                sentPhones.add(phone); // 발송한 번호 기록
+                successCount++;
+
+            } catch (Exception e) {
+                System.out.println("문자 발송 실패 (phone=" + phone + "): " + e.getMessage());
                 failCount++;
             }
         }
 
-        // 테스트
-        System.out.println("[문자 발송 결과] adminId=" + adminId
-                + ", performanceId=" + performance.getId()
-                + ", success=" + successCount
-                + ", fail=" + failCount);
+        // 로그
+        String resultMessage = String.format(
+                "[문자 발송 결과]\n성공: %d명\n실패: %d명",
+                successCount, failCount
+        );
+
+        // 디스코드
+        log.info(resultMessage);
+        discordWebhookSender.sendLog(resultMessage);
     }
 
     // 사전예매 확인 문자 발송

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -100,5 +100,52 @@ public class AdminMessageServiceImpl implements AdminMessageService {
                 + ", fail=" + failCount);
     }
 
+    // 사전예매 확인 문자 발송
+    @Override
+    public void sendBookingConfirmationMessage(String phoneNumber, String name, int headCount, int totalPrice, String openchatUrl) {
+        try {
+            DefaultMessageService smsService =
+                    NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+
+            Message message = new Message();
+            message.setFrom(sender);
+            message.setTo(phoneNumber);
+//            String webUrl = "https://deulbull.netlify.app/";
+            // 문자 내용 작성
+//            String messageText = String.format(
+//                    "[들불] Ready to Fire 정기공연 사전예매 완료 안내\n\n" +
+//                    "예매자: %s님\n" +
+//                    "인원: %d명\n" +
+//                    "총 금액: %,d원\n\n" +
+//
+//                    "[공연 정보]\n" +
+//                    "- 날짜: 12/21(토) 17:00 공연\n" +
+//                    "입장: 16:30부터 관객 입장 시작\n" +
+//                    "- 장소: 홍대 프리버드 리부트\n\n" +
+//
+//                    "문의 및 공연 정보:\n%s\n\n" +
+//                    "Website: %s\n"+
+//
+//                    "예매해주셔서 감사합니다.\n" +
+//                    "공연 당일에 뵙겠습니다!\n\n",
+//                    name, headCount, totalPrice, openchatUrl, webUrl
+//            );
+
+            String messageText = String.format(
+                    "[들불] %s님 %s명 예매완료\n"+
+                    "일시: 12/21(일) 17시\n"+
+                    "문의: %s"
+            , name, headCount, openchatUrl );
+
+            message.setText(messageText);
+
+            smsService.sendOne(new SingleMessageSendingRequest(message));
+
+            System.out.println("[예매 확인 문자 발송 성공] to=" + phoneNumber + ", name=" + name);
+        } catch (Exception e) {
+            System.out.println("[예매 확인 문자 발송 실패] to=" + phoneNumber + ", error=" + e.getMessage());
+            // 문자 발송 실패해도 예매는 정상적으로 처리되도록 예외를 던지지 않음
+        }
+    }
 
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminMessageServiceImpl.java
@@ -148,4 +148,5 @@ public class AdminMessageServiceImpl implements AdminMessageService {
         }
     }
 
+
 }

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminPerformanceServiceImpl.java
@@ -22,6 +22,7 @@ public class AdminPerformanceServiceImpl implements AdminPerformanceService {
     private final PerformanceSongsRepository performanceSongsRepository;
     private final PerformanceRepository performanceRepository;
 
+    // 현재 곡 조회
     @Override
     public AdminCurrentSongResponseDto getCurrentSong(Long adminId) {
         Admin admin = adminRepository.findById(adminId)

--- a/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/service/AdminServiceImpl.java
@@ -70,6 +70,7 @@ public class AdminServiceImpl implements AdminService {
         );
     }
 
+    // 회원가입
     @Transactional
     @Override
     public AdminSignupResponseDto signup(AdminSignupRequestDto adminSignupRequestDto) {

--- a/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/deulbull/performance/domain/admin/web/controller/AdminController.java
@@ -54,7 +54,7 @@ public class AdminController {
         return SuccessResponse.ok(data);
     }
 
-    // 예매 정보 수정
+    // 예매 수정
     @PatchMapping("/bookings/{bookingId}")
     public SuccessResponse<Void> updateBooking(
             @AuthenticationPrincipal(errorOnInvalidType = false) CustomUserDetails userDetails,

--- a/src/main/java/com/deulbull/performance/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/repository/BookingRepository.java
@@ -20,7 +20,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     // 특정 공연의 예매 목록 조회 - 이름 검색 (페이징)
     Page<Booking> findByPerformanceAndNameContaining(Performance performance, String name, Pageable pageable);
 
-    // 특정 공연의 총 예매 건수
+    // 특정 공연의 총 예매 건수 - 단순 엔티티 수 반환
     long countByPerformance(Performance performance);
 
     // 특정 공연의 총 예매 건수 - 이름 검색

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -152,7 +152,7 @@ public class BookingServiceImpl implements BookingService {
         Integer totalBookingCount = bookingRepository.sumHeadCountByPerformance(booking.getPerformance());
         LocalDateTime now = LocalDateTime.now();
 
-        // 디스코드 알림 메시지
+        // 디스코드 알림 메시지(관리자)
         String discordMessage = String.format(
                 "[예매 수정]\n" +
                         "예매 ID: %d\n\n" +
@@ -173,6 +173,14 @@ public class BookingServiceImpl implements BookingService {
                 booking.formatDateTimeWithDay(now),
                 totalBookingCount
         );
+
+        // 문자(예매자)
+        adminMessageService.sendSimpleAdminMessage(
+                requestDto.phoneNumber(),
+                String.format("[들불] 예매 수정\n%s: %d→%d명",
+                        requestDto.name(), oldHeadCount, requestDto.headCount())
+        );
+
 
         discordWebhookSender.send(discordMessage);
     }
@@ -197,7 +205,7 @@ public class BookingServiceImpl implements BookingService {
         int totalBookingCount = bookingRepository.sumHeadCountByPerformance(booking.getPerformance());
         LocalDateTime now = LocalDateTime.now();
 
-        // 디스코드 메시지
+        // 디스코드 메시지(관리자)
         String discordMessage = String.format(
                 "[예매 삭제]\n" +
                         "예매 ID: %d\n" +
@@ -211,6 +219,12 @@ public class BookingServiceImpl implements BookingService {
                 name, phone, headCount,
                 booking.formatDateTimeWithDay(now),
                 totalBookingCount
+        );
+
+        // 문자(예매자)
+        adminMessageService.sendSimpleAdminMessage(
+                phone,
+                String.format("[들불] 예매 삭제\n%s, %d명", name, headCount)
         );
 
         discordWebhookSender.send(discordMessage);

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -1,5 +1,6 @@
 package com.deulbull.performance.domain.booking.service;
 
+import com.deulbull.performance.domain.admin.service.AdminMessageService;
 import com.deulbull.performance.domain.booking.entity.Booking;
 import com.deulbull.performance.domain.booking.exception.BookingDeadlinePassedException;
 import com.deulbull.performance.domain.booking.exception.BookingNotFoundException;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 public class BookingServiceImpl implements BookingService {
     private final BookingRepository bookingRepository;
     private final PerformanceRepository performanceRepository;
+    private final AdminMessageService adminMessageService;
 
     @Override
     @Transactional
@@ -47,6 +49,18 @@ public class BookingServiceImpl implements BookingService {
                 .build();
 
         bookingRepository.save(booking);
+
+        // 4. 예매 확인 문자 발송
+        int totalPrice = (performance.getPreSaleFee() != null ? performance.getPreSaleFee() : 0) * requestDto.headCount();
+        String openchatUrl = performance.getOpenchatUrl() != null ? performance.getOpenchatUrl() : "오픈채팅 URL 미등록";
+
+        adminMessageService.sendBookingConfirmationMessage(
+                requestDto.phoneNumber(),
+                requestDto.name(),
+                requestDto.headCount(),
+                totalPrice,
+                openchatUrl
+        );
     }
 
     @Override

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -85,7 +85,7 @@ public class BookingServiceImpl implements BookingService {
                 booking.formatDateTimeWithDay(now),
                 totalBookingCount
         );
-        discordWebhookSender.send(discordMessage);
+        discordWebhookSender.sendBooking(discordMessage);
 
         // 6. 예매 확인 문자 발송
         String openchatUrl = performance.getOpenchatUrl() != null ? performance.getOpenchatUrl() : "오픈채팅 URL 미등록";
@@ -182,7 +182,7 @@ public class BookingServiceImpl implements BookingService {
         );
 
 
-        discordWebhookSender.send(discordMessage);
+        discordWebhookSender.sendBooking(discordMessage);
     }
 
 
@@ -227,7 +227,7 @@ public class BookingServiceImpl implements BookingService {
                 String.format("[들불] 예매 삭제\n%s, %d명", name, headCount)
         );
 
-        discordWebhookSender.send(discordMessage);
+        discordWebhookSender.sendBooking(discordMessage);
     }
 
 }

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -12,7 +12,10 @@ import com.deulbull.performance.domain.booking.web.dto.PreBookingInfoResponse;
 import com.deulbull.performance.domain.performance.entity.Performance;
 import com.deulbull.performance.domain.performance.exception.PerformanceNotFoundException;
 import com.deulbull.performance.domain.performance.repository.PerformanceRepository;
+import com.deulbull.performance.global.discord.DiscordWebhookSender;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,9 +24,11 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 public class BookingServiceImpl implements BookingService {
+    private static final Logger log = LoggerFactory.getLogger(BookingServiceImpl.class);
     private final BookingRepository bookingRepository;
     private final PerformanceRepository performanceRepository;
     private final AdminMessageService adminMessageService;
+    private final DiscordWebhookSender discordWebhookSender;
 
     @Override
     @Transactional
@@ -47,11 +52,42 @@ public class BookingServiceImpl implements BookingService {
                 .headCount(requestDto.headCount())
                 .performance(performance)
                 .build();
-
         bookingRepository.save(booking);
 
-        // 4. 예매 확인 문자 발송
+        // 4. 콘솔 로그
         int totalPrice = (performance.getPreSaleFee() != null ? performance.getPreSaleFee() : 0) * requestDto.headCount();
+        log.info("[예매 생성] performanceId={}, name={}, phone={}, headCount={}, paymentMethod={}, totalPrice={}",
+                performanceId,
+                requestDto.name(),
+                requestDto.phoneNumber(),
+                requestDto.headCount(),
+                requestDto.paymentMethod(),
+                totalPrice
+        );
+
+        Long totalBookingCount = bookingRepository.countByPerformance(performance);
+        // 5. discord 웹훅 알림
+        String discordMessage = String.format(
+                "[예매 추가]\n" +
+                        "이름: %s\n" +
+                        "연락처: %s\n" +
+                        "인원: %d명\n" +
+                        "총 금액: %,d원\n" +
+                        "마지막 선택한 결제 방식: %s\n" +
+                        "시간: %s\n"+
+                        "📍예매 누적 인원: %d명\n" +
+                        "=====================",
+                requestDto.name(),
+                requestDto.phoneNumber(),
+                requestDto.headCount(),
+                totalPrice,
+                requestDto.paymentMethod(),
+                booking.formatDateTimeWithDay(now),
+                totalBookingCount
+        );
+        discordWebhookSender.send(discordMessage);
+
+        // 6. 예매 확인 문자 발송
         String openchatUrl = performance.getOpenchatUrl() != null ? performance.getOpenchatUrl() : "오픈채팅 URL 미등록";
 
         adminMessageService.sendBookingConfirmationMessage(
@@ -94,6 +130,7 @@ public class BookingServiceImpl implements BookingService {
         );
     }
 
+    // 예매 수정
     @Override
     @Transactional
     public void updateBooking(Long bookingId, BookingUpdateRequestDto requestDto) {
@@ -101,11 +138,45 @@ public class BookingServiceImpl implements BookingService {
         Booking booking = bookingRepository.findById(bookingId)
                 .orElseThrow(BookingNotFoundException::new);
 
-        // 2. 예매 정보 수정 (JPA 변경 감지로 자동 업데이트)
+        // 기존 값 (로그용)
+        String oldName = booking.getName();
+        String oldPhone = booking.getPhoneNumber();
+        int oldHeadCount = booking.getHeadCount();
+
+        // 변경 적용
         booking.setName(requestDto.name());
         booking.setPhoneNumber(requestDto.phoneNumber());
         booking.setHeadCount(requestDto.headCount());
+
+        // 변경 후 누적 인원
+        Integer totalBookingCount = bookingRepository.sumHeadCountByPerformance(booking.getPerformance());
+        LocalDateTime now = LocalDateTime.now();
+
+        // 디스코드 알림 메시지
+        String discordMessage = String.format(
+                "[예매 수정]\n" +
+                        "예매 ID: %d\n\n" +
+                        "[변경 전]\n" +
+                        "- 이름: %s\n" +
+                        "- 연락처: %s\n" +
+                        "- 인원: %d명\n\n" +
+                        "[변경 후]\n" +
+                        "- 이름: %s\n" +
+                        "- 연락처: %s\n" +
+                        "- 인원: %d명\n\n" +
+                        "시간: %s\n" +
+                        "📍수정 후 예매 누적 인원: %d명\n" +
+                        "=====================",
+                bookingId,
+                oldName, oldPhone, oldHeadCount,
+                requestDto.name(), requestDto.phoneNumber(), requestDto.headCount(),
+                booking.formatDateTimeWithDay(now),
+                totalBookingCount
+        );
+
+        discordWebhookSender.send(discordMessage);
     }
+
 
     @Override
     @Transactional
@@ -114,7 +185,35 @@ public class BookingServiceImpl implements BookingService {
         Booking booking = bookingRepository.findById(bookingId)
                 .orElseThrow(BookingNotFoundException::new);
 
-        // 2. 예매 삭제
+        // 로그용 백업
+        String name = booking.getName();
+        String phone = booking.getPhoneNumber();
+        int headCount = booking.getHeadCount();
+
+        // 삭제
         bookingRepository.delete(booking);
+
+        // 삭제 후 누적 인원
+        int totalBookingCount = bookingRepository.sumHeadCountByPerformance(booking.getPerformance());
+        LocalDateTime now = LocalDateTime.now();
+
+        // 디스코드 메시지
+        String discordMessage = String.format(
+                "[예매 삭제]\n" +
+                        "예매 ID: %d\n" +
+                        "이름: %s\n" +
+                        "연락처: %s\n" +
+                        "인원: %d명\n\n" +
+                        "시간: %s\n" +
+                        "📍삭제 후 예매 누적 인원: %d명\n" +
+                        "=====================",
+                bookingId,
+                name, phone, headCount,
+                booking.formatDateTimeWithDay(now),
+                totalBookingCount
+        );
+
+        discordWebhookSender.send(discordMessage);
     }
+
 }

--- a/src/main/java/com/deulbull/performance/domain/booking/web/dto/BookingRequestDto.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/web/dto/BookingRequestDto.java
@@ -15,6 +15,7 @@ public record BookingRequestDto(
 
         @NotNull(message = "인원수는 필수 입력 항목입니다.")
         @Positive(message = "인원수는 1명 이상이어야 합니다.")
-        Integer headCount
+        Integer headCount,
+        String paymentMethod // 결제 방법(가장 마지막 선택한 방법)
 ) {
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/repository/PerformanceImageRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/repository/PerformanceImageRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface PerformanceImageRepository extends JpaRepository<PerformanceImage, Long> {
     List<PerformanceImage> findAllByPerformanceId(Long performance_id);
+
+    void deleteAllByPerformanceId(Long performanceId);
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceService.java
@@ -20,4 +20,7 @@ public interface PerformanceService {
 
     // 공연 셋리스트 조회
     PerformanceSetlistResponse getPerformanceSetlist(Long performanceId);
+
+    // 공연 이미지 교체
+    void replacePerformanceImages(Long performanceId, List<MultipartFile> newImages);
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -382,9 +382,9 @@ public class PerformanceServiceImpl implements PerformanceService {
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(PerformanceNotFoundException::new);
 
-        // 1) S3에서 해당 performance 폴더 전체 삭제
+//        // 1) S3에서 해당 performance 폴더 전체 삭제
         String folderPrefix = "performance/" + performanceId + "/";
-        s3Uploader.deleteFolder(folderPrefix);
+//        s3Uploader.deleteFolder(folderPrefix);
 
         // 2) DB 기존 이미지 삭제
         performanceImageRepository.deleteAllByPerformanceId(performanceId);

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -371,5 +372,51 @@ public class PerformanceServiceImpl implements PerformanceService {
                             .build();
                     return personRepository.save(newPerson);
                 });
+    }
+
+    // 공연 이미지 교체
+    @Override
+    @Transactional
+    public void replacePerformanceImages(Long performanceId, List<MultipartFile> newImages) {
+
+        Performance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(PerformanceNotFoundException::new);
+
+        // 1) S3에서 해당 performance 폴더 전체 삭제
+        String folderPrefix = "performance/" + performanceId + "/";
+        s3Uploader.deleteFolder(folderPrefix);
+
+        // 2) DB 기존 이미지 삭제
+        performanceImageRepository.deleteAllByPerformanceId(performanceId);
+
+        // 3) 새 이미지 업로드
+        List<String> newUrls = new ArrayList<>();
+
+        if (newImages != null && !newImages.isEmpty()) {
+            for (MultipartFile image : newImages) {
+                if (image == null || image.isEmpty()) continue;
+
+                String url = s3Uploader.upload(
+                        image,
+                        folderPrefix + UUID.randomUUID()  // index 대신 uuid 사용
+                );
+
+                newUrls.add(url);
+            }
+        }
+
+        // 4) DB 저장
+        if (!newUrls.isEmpty()) {
+            List<PerformanceImage> imgs = newUrls.stream()
+                    .map(url -> PerformanceImage.builder()
+                            .performance(performance)
+                            .imageUrl(url)
+                            .build())
+                    .toList();
+
+            performanceImageRepository.saveAll(imgs);
+        }
+
+        System.out.println("[공연 이미지 교체 완료] performanceId=" + performanceId);
     }
 }

--- a/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/controller/PerformanceController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequestMapping("/performances")
@@ -47,5 +48,15 @@ public class PerformanceController {
     ){
         PerformanceSetlistResponse response = performanceService.getPerformanceSetlist(performanceId);
         return SuccessResponse.ok(response);
+    }
+
+    // 공연 이미지 교체
+    @PutMapping(value = "/{performanceId}/images", consumes = {"multipart/form-data"})
+    public SuccessResponse<Void> replacePerformanceImages(
+            @PathVariable Long performanceId,
+            @RequestPart("images") List<MultipartFile> images
+    ) {
+        performanceService.replacePerformanceImages(performanceId, images);
+        return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/com/deulbull/performance/global/discord/DiscordWebhookSender.java
+++ b/src/main/java/com/deulbull/performance/global/discord/DiscordWebhookSender.java
@@ -1,0 +1,28 @@
+package com.deulbull.performance.global.discord;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordWebhookSender {
+
+    @Value("${discord.booking.webhook}")
+    private String webhookUrl;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void send(String message) {
+        try {
+            Map<String, String> body = Map.of("content", message);
+
+            restTemplate.postForObject(webhookUrl, body, String.class);
+        } catch (Exception e) {
+            System.out.println("[디스코드 전송 실패] " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/deulbull/performance/global/discord/DiscordWebhookSender.java
+++ b/src/main/java/com/deulbull/performance/global/discord/DiscordWebhookSender.java
@@ -12,17 +12,28 @@ import java.util.Map;
 public class DiscordWebhookSender {
 
     @Value("${discord.booking.webhook}")
-    private String webhookUrl;
+    private String bookingWebhook;
+
+    @Value("${discord.log.webhook}")
+    private String logWebhook;
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public void send(String message) {
+    public void sendBooking(String message) {
+        sendToWebhook(bookingWebhook, message);
+    }
+
+    public void sendLog(String message) {
+        sendToWebhook(logWebhook, message);
+    }
+
+    private void sendToWebhook(String webhookUrl, String message) {
         try {
             Map<String, String> body = Map.of("content", message);
-
             restTemplate.postForObject(webhookUrl, body, String.class);
         } catch (Exception e) {
-            System.out.println("[디스코드 전송 실패] " + e.getMessage());
+            System.out.println("[디스코드 전송 실패] url=" + webhookUrl + ", error=" + e.getMessage());
         }
     }
 }
+

--- a/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
+++ b/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
@@ -1,5 +1,6 @@
 package com.deulbull.performance.global.s3;
 
+import com.luciad.imageio.webp.WebPWriteParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -8,7 +9,15 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.UUID;
 
 @Component
@@ -21,30 +30,60 @@ public class S3Uploader {
     private String bucket;
 
     public String upload(MultipartFile file, String keyPrefix) {
-        String ext = getExtension(file.getOriginalFilename());
-        String key = keyPrefix + "-" + UUID.randomUUID() + "." + ext;
 
         try {
+            // 1) MultipartFile → BufferedImage
+            BufferedImage image = ImageIO.read(file.getInputStream());
+            if (image == null) {
+                throw new RuntimeException("이미지 변환 실패: 지원되지 않는 포맷");
+            }
+
+            // 2) WebP로 변환
+            byte[] webpBytes = convertToWebP(image, 0.9f); // 90% 품질
+
+            // 3) 파일명 .webp로 저장
+            String key = keyPrefix + "-" + UUID.randomUUID() + ".webp";
+
+            // 4) S3 업로드
             s3Client.putObject(
                     PutObjectRequest.builder()
                             .bucket(bucket)
                             .key(key)
-                            .contentType(file.getContentType())
-                            .cacheControl("max-age=2592000, public") 
+                            .contentType("image/webp")
+                            .cacheControl("max-age=2592000, public")
                             .build(),
-                    RequestBody.fromBytes(file.getBytes())
+                    RequestBody.fromBytes(webpBytes)
             );
-        } catch (IOException e) {
-            throw new RuntimeException("S3 업로드 실패", e);
-        }
 
-        return "https://" + bucket + ".s3.amazonaws.com/" + key;
+            // 5) 반환 URL
+            return "https://" + bucket + ".s3.amazonaws.com/" + key;
+
+        } catch (IOException e) {
+            throw new RuntimeException("WebP 변환 또는 S3 업로드 실패", e);
+        }
     }
 
-    private String getExtension(String filename) {
-        if (filename == null) return "dat";
-        int idx = filename.lastIndexOf('.');
-        if (idx == -1) return "dat";
-        return filename.substring(idx + 1);
+    // WebP 변환 함수
+    private byte[] convertToWebP(BufferedImage image, float quality) throws IOException {
+
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByMIMEType("image/webp");
+        if (!writers.hasNext()) {
+            throw new IllegalStateException("WebP ImageWriter를 찾을 수 없습니다.");
+        }
+
+        ImageWriter writer = writers.next();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos);
+        writer.setOutput(output);
+
+        WebPWriteParam writeParam = new WebPWriteParam(writer.getLocale());
+        writeParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        writeParam.setCompressionQuality(quality); // 0.0 ~ 1.0
+
+        writer.write(null, new IIOImage(image, null, null), writeParam);
+        writer.dispose();
+
+        return baos.toByteArray();
     }
 }

--- a/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
+++ b/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
@@ -1,14 +1,12 @@
 package com.deulbull.performance.global.s3;
 
-import com.luciad.imageio.webp.WebPWriteParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -30,96 +28,127 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+
     public String upload(MultipartFile file, String keyPrefix) {
 
+        String originalExt = getExtension(file.getOriginalFilename()).toLowerCase();
+        long fileSize = file.getSize();
+
+        byte[] finalBytes;
+        String finalExt = originalExt;
+
         try {
-            // 1) MultipartFile → BufferedImage
-            BufferedImage image = ImageIO.read(file.getInputStream());
-            if (image == null) {
-                throw new RuntimeException("이미지 변환 실패: 지원되지 않는 포맷");
+            // PNG가 너무 클 때만 JPEG로 변환
+            if (originalExt.equals("png") && fileSize > 1_000_000) { // 1MB 이상
+                BufferedImage image = ImageIO.read(file.getInputStream());
+                finalBytes = convertPngToJpeg(image, 0.9f); // 품질 90%
+                finalExt = "jpg";
+            } else {
+                // 변환 없이 그대로 사용
+                finalBytes = file.getBytes();
             }
 
-            // 2) WebP로 변환
-            byte[] webpBytes = convertToWebP(image, 0.9f); // 90% 품질
+            // S3 저장 키
+            String key = keyPrefix + "-" + UUID.randomUUID() + "." + finalExt;
 
-            // 3) 파일명 .webp로 저장
-            String key = keyPrefix + "-" + UUID.randomUUID() + ".webp";
-
-            // 4) S3 업로드
             s3Client.putObject(
                     PutObjectRequest.builder()
                             .bucket(bucket)
                             .key(key)
-                            .contentType("image/webp")
+                            .contentType("image/" + finalExt)
                             .cacheControl("max-age=2592000, public")
                             .build(),
-                    RequestBody.fromBytes(webpBytes)
+                    RequestBody.fromBytes(finalBytes)
             );
 
-            // 5) 반환 URL
             return "https://" + bucket + ".s3.amazonaws.com/" + key;
 
         } catch (IOException e) {
-            throw new RuntimeException("WebP 변환 또는 S3 업로드 실패", e);
+            throw new RuntimeException("이미지 처리 또는 S3 업로드 실패", e);
         }
     }
 
-    // S3에서 파일 삭제
-    public void delete(String fileUrl) {
-        try {
-            // URL에서 키 추출
-            String key = extractKeyFromUrl(fileUrl);
 
-            s3Client.deleteObject(
-                    DeleteObjectRequest.builder()
-                            .bucket(bucket)
-                            .key(key)
-                            .build()
-            );
 
-            System.out.println("[S3 삭제 성공] key=" + key);
-        } catch (Exception e) {
-            System.out.println("[S3 삭제 실패] url=" + fileUrl + ", error=" + e.getMessage());
-            // 삭제 실패해도 예외를 던지지 않음 (이미 삭제된 파일일 수 있음)
-        }
-    }
+    // PNG → JPEG 변환
+    private byte[] convertPngToJpeg(BufferedImage image, float quality) throws IOException {
 
-    // URL에서 S3 키 추출
-    private String extractKeyFromUrl(String fileUrl) {
-        // https://bucket-name.s3.amazonaws.com/key 형식에서 key 추출
-        if (fileUrl == null || fileUrl.isEmpty()) {
-            return "";
-        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        String[] parts = fileUrl.split(bucket + ".s3.amazonaws.com/");
-        if (parts.length > 1) {
-            return parts[1];
-        }
-
-        return "";
-    }
-
-    // WebP 변환 함수
-    private byte[] convertToWebP(BufferedImage image, float quality) throws IOException {
-
-        Iterator<ImageWriter> writers = ImageIO.getImageWritersByMIMEType("image/webp");
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpg");
         if (!writers.hasNext()) {
-            throw new IllegalStateException("WebP ImageWriter를 찾을 수 없습니다.");
+            throw new IllegalStateException("JPEG ImageWriter를 찾을 수 없습니다.");
         }
 
         ImageWriter writer = writers.next();
+        ImageWriteParam param = writer.getDefaultWriteParam();
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        param.setCompressionQuality(quality);
+
         MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos);
         writer.setOutput(output);
 
-        WebPWriteParam writeParam = new WebPWriteParam(writer.getLocale());
-        writeParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-        writeParam.setCompressionQuality(quality); // 0.0 ~ 1.0
-
-        writer.write(null, new IIOImage(image, null, null), writeParam);
+        writer.write(null, new IIOImage(image, null, null), param);
         writer.dispose();
 
         return baos.toByteArray();
     }
+
+
+
+    // 단일 삭제
+    public void delete(String fileUrl) {
+        try {
+            String key = extractKeyFromUrl(fileUrl);
+
+            if (!key.isEmpty()) {
+                s3Client.deleteObject(
+                        DeleteObjectRequest.builder()
+                                .bucket(bucket)
+                                .key(key)
+                                .build()
+                );
+            }
+
+        } catch (Exception ignored) {}
+    }
+
+
+    // URL → key 추출
+    private String extractKeyFromUrl(String fileUrl) {
+        if (fileUrl == null) return "";
+        String[] parts = fileUrl.split(bucket + ".s3.amazonaws.com/");
+        return (parts.length > 1) ? parts[1] : "";
+    }
+
+
+    private String getExtension(String filename) {
+        if (filename == null) return "dat";
+        int idx = filename.lastIndexOf('.');
+        if (idx == -1) return "dat";
+        return filename.substring(idx + 1);
+    }
+
+    // 폴더 삭제
+    public void deleteFolder(String prefix) {
+        ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .build();
+
+        ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+
+        for (S3Object obj : listResponse.contents()) {
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(obj.key())
+                            .build()
+            );
+        }
+
+        System.out.println("[S3 폴더 삭제 완료] prefix=" + prefix);
+    }
+
 }

--- a/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
+++ b/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
@@ -8,15 +8,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.MemoryCacheImageOutputStream;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.UUID;
 
 @Component
@@ -28,118 +20,50 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-
     public String upload(MultipartFile file, String keyPrefix) {
-
-        String originalExt = getExtension(file.getOriginalFilename()).toLowerCase();
-        long fileSize = file.getSize();
-
-        byte[] finalBytes;
-        String finalExt = originalExt;
+        String ext = getExtension(file.getOriginalFilename()).toLowerCase();
+        String key = keyPrefix + "-" + UUID.randomUUID() + "." + ext;
 
         try {
-            // PNG가 너무 클 때만 JPEG로 변환
-            if (originalExt.equals("png") && fileSize > 1_000_000) { // 1MB 이상
-                BufferedImage image = ImageIO.read(file.getInputStream());
-                finalBytes = convertPngToJpeg(image, 0.9f); // 품질 90%
-                finalExt = "jpg";
-            } else {
-                // 변환 없이 그대로 사용
-                finalBytes = file.getBytes();
-            }
-
-            // S3 저장 키
-            String key = keyPrefix + "-" + UUID.randomUUID() + "." + finalExt;
-
             s3Client.putObject(
                     PutObjectRequest.builder()
                             .bucket(bucket)
                             .key(key)
-                            .contentType("image/" + finalExt)
+                            .contentType(file.getContentType())
                             .cacheControl("max-age=2592000, public")
                             .build(),
-                    RequestBody.fromBytes(finalBytes)
+                    RequestBody.fromBytes(file.getBytes())
             );
-
-            return "https://" + bucket + ".s3.amazonaws.com/" + key;
-
         } catch (IOException e) {
-            throw new RuntimeException("이미지 처리 또는 S3 업로드 실패", e);
-        }
-    }
-
-
-
-    // PNG → JPEG 변환
-    private byte[] convertPngToJpeg(BufferedImage image, float quality) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpg");
-        if (!writers.hasNext()) {
-            throw new IllegalStateException("JPEG ImageWriter를 찾을 수 없습니다.");
+            throw new RuntimeException("S3 업로드 실패", e);
         }
 
-        ImageWriter writer = writers.next();
-        ImageWriteParam param = writer.getDefaultWriteParam();
-
-        param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-        param.setCompressionQuality(quality);
-
-        MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos);
-        writer.setOutput(output);
-
-        writer.write(null, new IIOImage(image, null, null), param);
-        writer.dispose();
-
-        return baos.toByteArray();
+        return "https://" + bucket + ".s3.amazonaws.com/" + key;
     }
 
-
-
-    // 단일 삭제
     public void delete(String fileUrl) {
+        String key = extractKeyFromUrl(fileUrl);
+        if (key.isEmpty()) return;
+
         try {
-            String key = extractKeyFromUrl(fileUrl);
-
-            if (!key.isEmpty()) {
-                s3Client.deleteObject(
-                        DeleteObjectRequest.builder()
-                                .bucket(bucket)
-                                .key(key)
-                                .build()
-                );
-            }
-
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .build()
+            );
         } catch (Exception ignored) {}
     }
 
-
-    // URL → key 추출
-    private String extractKeyFromUrl(String fileUrl) {
-        if (fileUrl == null) return "";
-        String[] parts = fileUrl.split(bucket + ".s3.amazonaws.com/");
-        return (parts.length > 1) ? parts[1] : "";
-    }
-
-
-    private String getExtension(String filename) {
-        if (filename == null) return "dat";
-        int idx = filename.lastIndexOf('.');
-        if (idx == -1) return "dat";
-        return filename.substring(idx + 1);
-    }
-
-    // 폴더 삭제
     public void deleteFolder(String prefix) {
-        ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
-                .bucket(bucket)
-                .prefix(prefix)
-                .build();
+        ListObjectsV2Response list = s3Client.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(bucket)
+                        .prefix(prefix)
+                        .build()
+        );
 
-        ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
-
-        for (S3Object obj : listResponse.contents()) {
+        for (S3Object obj : list.contents()) {
             s3Client.deleteObject(
                     DeleteObjectRequest.builder()
                             .bucket(bucket)
@@ -147,8 +71,17 @@ public class S3Uploader {
                             .build()
             );
         }
-
-        System.out.println("[S3 폴더 삭제 완료] prefix=" + prefix);
     }
 
+    private String extractKeyFromUrl(String fileUrl) {
+        if (fileUrl == null) return "";
+        String[] parts = fileUrl.split(bucket + ".s3.amazonaws.com/");
+        return parts.length > 1 ? parts[1] : "";
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null) return "dat";
+        int idx = filename.lastIndexOf('.');
+        return (idx == -1) ? "dat" : filename.substring(idx + 1);
+    }
 }

--- a/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
+++ b/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
@@ -30,6 +30,7 @@ public class S3Uploader {
                             .bucket(bucket)
                             .key(key)
                             .contentType(file.getContentType())
+                            .cacheControl("max-age=2592000, public") 
                             .build(),
                     RequestBody.fromBytes(file.getBytes())
             );

--- a/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
+++ b/src/main/java/com/deulbull/performance/global/s3/S3Uploader.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import javax.imageio.IIOImage;
@@ -61,6 +62,41 @@ public class S3Uploader {
         } catch (IOException e) {
             throw new RuntimeException("WebP 변환 또는 S3 업로드 실패", e);
         }
+    }
+
+    // S3에서 파일 삭제
+    public void delete(String fileUrl) {
+        try {
+            // URL에서 키 추출
+            String key = extractKeyFromUrl(fileUrl);
+
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .build()
+            );
+
+            System.out.println("[S3 삭제 성공] key=" + key);
+        } catch (Exception e) {
+            System.out.println("[S3 삭제 실패] url=" + fileUrl + ", error=" + e.getMessage());
+            // 삭제 실패해도 예외를 던지지 않음 (이미 삭제된 파일일 수 있음)
+        }
+    }
+
+    // URL에서 S3 키 추출
+    private String extractKeyFromUrl(String fileUrl) {
+        // https://bucket-name.s3.amazonaws.com/key 형식에서 key 추출
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return "";
+        }
+
+        String[] parts = fileUrl.split(bucket + ".s3.amazonaws.com/");
+        if (parts.length > 1) {
+            return parts[1];
+        }
+
+        return "";
     }
 
     // WebP 변환 함수

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,8 @@ management:
     metrics:
       export:
         enabled: true
+
+discord:
+  booking:
+    webhook: https://discord.com/api/webhooks/1447316749660848208/5F0SCRXsKyHk1A0ZzUq1VjYKCJBHI_f3h9b2TKecqbNs7ea55TmxuXkvYO_2L-oPRo9x
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,4 +28,5 @@ management:
 discord:
   booking:
     webhook: https://discord.com/api/webhooks/1447316749660848208/5F0SCRXsKyHk1A0ZzUq1VjYKCJBHI_f3h9b2TKecqbNs7ea55TmxuXkvYO_2L-oPRo9x
-
+  log:
+    webhook: https://discord.com/api/webhooks/1447329231842578636/HrnyrsQBkRCHW4rMqjGgNg9FmoRSy8TJK9zp7Yih7lkgFwB3tciKPX0EyVgbGctYQRmV


### PR DESCRIPTION
## 연관 이슈
- close #92

## 작업 내용
- 사전예매 응답값에 입장 시작 시간(16:30) 필드 추가
- 예매 생성 시 문자 발송 로직 추가 및 개선
- S3 업로드 시 cacheControl 적용(캐싱 및 CDN 배포를 위한 사전 작업)
- Docker 실행 시 서버 타임존을 Asia/Seoul 로 고정
- 예매 알림 메시지 구조 개선 및 로깅 정교화
- Discord Webhook 기반 알림 구조 도입 준비

## 논의하고 싶은 내용
- 문자 발송 실패 시 알림/로그 처리 방식 결정
- 캐싱 정책을 CloudFront 적용 기준으로 확대해야 할지 여부

## 공유하고 싶은 내용
- 캐시Control 적용 결과 초기 S3 응답 개선 효과 확인
- 서버 타임존 고정으로 예약/로그 시간 불일치 문제 해결됨

## 기타
- CoolSMS 크레딧 충전 필요