### PR TITLE
fix(booking): synchronized + flush를 사용한 예매 중복 생성 방지

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/repository/BookingRepository.java
@@ -35,4 +35,15 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     Integer sumHeadCountByPerformanceAndNameContaining(@Param("performance") Performance performance, @Param("name") String name);
 
     List<Booking> findAllByPerformanceId(Long performanceId);
+
+    // 중복 예매 방지: 특정 시간 이후 같은 이름+전화번호로 예매한 내역이 있는지 확인
+    @Query("SELECT COUNT(b) > 0 FROM Booking b WHERE b.performance.id = :performanceId " +
+           "AND b.name = :name AND b.phoneNumber = :phoneNumber " +
+           "AND b.createdAt > :afterTime")
+    boolean existsRecentBooking(
+            @Param("performanceId") Long performanceId,
+            @Param("name") String name,
+            @Param("phoneNumber") String phoneNumber,
+            @Param("afterTime") java.time.LocalDateTime afterTime
+    );
 }

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -45,6 +45,45 @@ public class BookingServiceImpl implements BookingService {
             throw new BookingDeadlinePassedException();
         }
 
+        // 3. 중복 예매 방지: 최근 3초 이내 동일 이름+전화번호 예매 체크
+        int seconds = 3;
+        LocalDateTime fewSecondsAgo = now.minusSeconds(seconds);
+        boolean isDuplicate = bookingRepository.existsRecentBooking(
+                performanceId,
+                requestDto.name(),
+                requestDto.phoneNumber(),
+                fewSecondsAgo
+        );
+
+        if (isDuplicate) {
+            // 중복 감지 시: DB 저장하지 않고 로깅과 디스코드 알림만 전송
+            log.warn("[중복 예매 감지] performanceId={}, name={}, phone={}, headCount={} - 3초 이내 중복 요청으로 저장하지 않음",
+                    performanceId,
+                    requestDto.name(),
+                    requestDto.phoneNumber(),
+                    requestDto.headCount()
+            );
+
+            String duplicateMessage = String.format(
+                    "[### ⚠️중복 예매 감지 - 저장 안 됨]\n" +
+                            "이름: **%s**\n" +
+                            "연락처: %s\n" +
+                            "인원: %d명\n" +
+                            "시간: %s\n" +
+                            "사유: %d초 이내 중복 요청\n" +
+                            "=====================",
+                    requestDto.name(),
+                    requestDto.phoneNumber(),
+                    requestDto.headCount(),
+                    now.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                    seconds
+            );
+            discordWebhookSender.sendBooking(duplicateMessage);
+
+            // TODO: 추후 프론트 측 중복 방지 완료 시 예외를 던져서 사용자에게 명확히 알리는 방식으로 변경 고려
+            return; // 성공 응답 반환 (프론트 에러 방지)
+        }
+
         // 3. 예매 생성
         Booking booking = Booking.builder()
                 .name(requestDto.name())
@@ -68,8 +107,8 @@ public class BookingServiceImpl implements BookingService {
         Long totalBookingCount = bookingRepository.countByPerformance(performance);
         // 5. discord 웹훅 알림
         String discordMessage = String.format(
-                "[예매 추가]\n" +
-                        "이름: %s\n" +
+                "### [예매 추가]\n" +
+                        "이름: **%s**\n" +
                         "연락처: %s\n" +
                         "인원: %d명\n" +
                         "총 금액: %,d원\n" +

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -25,6 +25,9 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class BookingServiceImpl implements BookingService {
     private static final Logger log = LoggerFactory.getLogger(BookingServiceImpl.class);
+    private static final Object BOOKING_LOCK = new Object(); // 명시적 락 객체
+    private static final int DUPLICATE_CHECK_SECONDS = 3; // 중복 예매 체크 시간 (초)
+
     private final BookingRepository bookingRepository;
     private final PerformanceRepository performanceRepository;
     private final AdminMessageService adminMessageService;
@@ -32,7 +35,8 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     @Transactional
-    public synchronized void createBooking(Long performanceId, BookingRequestDto requestDto) {
+    public void createBooking(Long performanceId, BookingRequestDto requestDto) {
+        synchronized (BOOKING_LOCK) {
         // 1. 공연 조회
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(PerformanceNotFoundException::new);
@@ -45,9 +49,8 @@ public class BookingServiceImpl implements BookingService {
             throw new BookingDeadlinePassedException();
         }
 
-        // 3. 중복 예매 방지: 최근 3초 이내 동일 이름+전화번호 예매 체크
-        int seconds = 3;
-        LocalDateTime fewSecondsAgo = now.minusSeconds(seconds);
+        // 3. 중복 예매 방지: 최근 N초 이내 동일 이름+전화번호 예매 체크
+        LocalDateTime fewSecondsAgo = now.minusSeconds(DUPLICATE_CHECK_SECONDS);
         boolean isDuplicate = bookingRepository.existsRecentBooking(
                 performanceId,
                 requestDto.name(),
@@ -76,7 +79,7 @@ public class BookingServiceImpl implements BookingService {
                     requestDto.phoneNumber(),
                     requestDto.headCount(),
                     now.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
-                    seconds
+                    DUPLICATE_CHECK_SECONDS
             );
             discordWebhookSender.sendBooking(duplicateMessage);
 
@@ -94,7 +97,7 @@ public class BookingServiceImpl implements BookingService {
         bookingRepository.save(booking);
         bookingRepository.flush(); // 즉시 DB 반영 (중복 체크가 다음 요청에서 작동하도록)
 
-        // 4. 콘솔 로그
+        // 5. 콘솔 로그
         int totalPrice = (performance.getPreSaleFee() != null ? performance.getPreSaleFee() : 0) * requestDto.headCount();
         log.info("[예매 생성] performanceId={}, name={}, phone={}, headCount={}, paymentMethod={}, totalPrice={}",
                 performanceId,
@@ -106,7 +109,7 @@ public class BookingServiceImpl implements BookingService {
         );
 
         Long totalBookingCount = bookingRepository.countByPerformance(performance);
-        // 5. discord 웹훅 알림
+        // 6. discord 웹훅 알림
         String discordMessage = String.format(
                 "## [예매 추가]\n" +
                         "이름: **%s**\n" +
@@ -127,7 +130,7 @@ public class BookingServiceImpl implements BookingService {
         );
         discordWebhookSender.sendBooking(discordMessage);
 
-        // 6. 예매 확인 문자 발송
+        // 7. 예매 확인 문자 발송
         String openchatUrl = performance.getOpenchatUrl() != null ? performance.getOpenchatUrl() : "오픈채팅 URL 미등록";
 
         adminMessageService.sendBookingConfirmationMessage(
@@ -137,6 +140,7 @@ public class BookingServiceImpl implements BookingService {
                 totalPrice,
                 openchatUrl
         );
+        } // synchronized 블록 종료
     }
 
     @Override

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -32,7 +32,7 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     @Transactional
-    public void createBooking(Long performanceId, BookingRequestDto requestDto) {
+    public synchronized void createBooking(Long performanceId, BookingRequestDto requestDto) {
         // 1. 공연 조회
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(PerformanceNotFoundException::new);
@@ -65,7 +65,7 @@ public class BookingServiceImpl implements BookingService {
             );
 
             String duplicateMessage = String.format(
-                    "[### ⚠️중복 예매 감지 - 저장 안 됨]\n" +
+                    "## [⚠️중복 예매 감지 - 저장 안 됨]\n" +
                             "이름: **%s**\n" +
                             "연락처: %s\n" +
                             "인원: %d명\n" +
@@ -107,7 +107,7 @@ public class BookingServiceImpl implements BookingService {
         Long totalBookingCount = bookingRepository.countByPerformance(performance);
         // 5. discord 웹훅 알림
         String discordMessage = String.format(
-                "### [예매 추가]\n" +
+                "## [예매 추가]\n" +
                         "이름: **%s**\n" +
                         "연락처: %s\n" +
                         "인원: %d명\n" +

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -84,7 +84,7 @@ public class BookingServiceImpl implements BookingService {
             return; // 성공 응답 반환 (프론트 에러 방지)
         }
 
-        // 3. 예매 생성
+        // 4. 예매 생성
         Booking booking = Booking.builder()
                 .name(requestDto.name())
                 .phoneNumber(requestDto.phoneNumber())
@@ -92,6 +92,7 @@ public class BookingServiceImpl implements BookingService {
                 .performance(performance)
                 .build();
         bookingRepository.save(booking);
+        bookingRepository.flush(); // 즉시 DB 반영 (중복 체크가 다음 요청에서 작동하도록)
 
         // 4. 콘솔 로그
         int totalPrice = (performance.getPreSaleFee() != null ? performance.getPreSaleFee() : 0) * requestDto.headCount();

--- a/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/booking/service/BookingServiceImpl.java
@@ -71,7 +71,7 @@ public class BookingServiceImpl implements BookingService {
                             "인원: %d명\n" +
                             "시간: %s\n" +
                             "사유: %d초 이내 중복 요청\n" +
-                            "=====================",
+                            "==========================================",
                     requestDto.name(),
                     requestDto.phoneNumber(),
                     requestDto.headCount(),
@@ -115,7 +115,7 @@ public class BookingServiceImpl implements BookingService {
                         "마지막 선택한 결제 방식: %s\n" +
                         "시간: %s\n"+
                         "📍예매 누적 인원: %d명\n" +
-                        "=====================",
+                        "==========================================",
                 requestDto.name(),
                 requestDto.phoneNumber(),
                 requestDto.headCount(),


### PR DESCRIPTION
## 연관 이슈
- close #94 

## 작업 내용
- 사전 예매 중복 이슈 감지 로직 추가 및 해결
- synchronized를 사용한 처리(단일 서버이기에 가능)
- 트랜잭션 커밋 타이밍으로 인한 중복을 방지하기 위해 예매 생성 후 flush()를 명시적으로 호출해서 즉시 DB에 반영하도록 수정
- synchronized (BOOKING_LOCK)을 사용하여 메서드 전체가 아닌 명시적 락 객체 사용

### 동작 원리
> 첫 번째 요청: BOOKING_LOCK을 획득 → 저장 → flush → 락 해제
> 두 번째 요청: 락 획득 → 중복 체크 → DB에 이미 있음 → 중복 감지 → 저장 안 함


### 1. 동시에 두개의 예매를 보낸 경우
- 프론트 응답
: 둘 다 200
<img width="1938" height="104" alt="image" src="https://github.com/user-attachments/assets/ff3ffb7e-cbdf-49e1-adbf-97176d2ddd44" />

- 백엔드 로직 처리
: 첫번째 예매는 정상처리, 두번째 예매는 중복 감지 후 저장하지 않음
<img width="489" height="193" alt="image" src="https://github.com/user-attachments/assets/402148ab-0a87-4e44-8639-f069ca916152" />

- 디스코드 웹훅
: 정상 처리 및 중복 감지 안내
<img width="299" height="412" alt="image" src="https://github.com/user-attachments/assets/5b454d84-064b-4a81-b272-59ba3fb13ec6" />

- 문자
: 첫번째 예매만 전송됨
<img width="279" height="138" alt="image" src="https://github.com/user-attachments/assets/c7dc6971-aa99-4dad-9bdd-3f016e49438a" />


### 2. 0.5초 간격으로 두개의 예매를 보낸 경우(1과 동일한 결과)
- 프론트 응답
: 둘 다 200

- 백엔드 로직 처리
: 첫번째 예매는 정상처리, 두번째 예매는 중복 감지 후 저장하지 않음
<img width="1034" height="185" alt="image" src="https://github.com/user-attachments/assets/6dc3b0e2-5372-45f0-987d-a9d90f87824d" />

- 디스코드 웹훅
: 정상 처리 및 중복 감지 안내
<img width="281" height="412" alt="image" src="https://github.com/user-attachments/assets/a2b6eb99-9543-4cef-9cd0-58b1beb9e473" />

- 문자
: 첫번째 예매만 전송됨
<img width="279" height="138" alt="image" src="https://github.com/user-attachments/assets/c7dc6971-aa99-4dad-9bdd-3f016e49438a" />


## 논의하고 싶은 내용
- 더 적절한 방법이 있다면 추후 리팩토링 시 반영하면 좋을 것 같습니다.

## 공유하고 싶은 내용
- 단일 서버이기에 synchronized를 예매 생성 메서드에 붙여 해결할 예정이지만, 이후 서버를 여러대로 확장하게 될 경우 Redis 분산 락이 필요합니다.


## 기타
- 기타 추가할 내용이 있다면 추가합니다.
- 없는 경우 삭제